### PR TITLE
Remove tomcat-embed-logging-log4j from Tomcat 8.5.3 on

### DIFF
--- a/libs/gretty-runner-tomcat8/build.gradle
+++ b/libs/gretty-runner-tomcat8/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.VersionNumber
+
 apply from: rootProject.file('common.gradle')
 
 dependencies {
@@ -8,7 +10,8 @@ dependencies {
   compile "org.apache.tomcat.embed:tomcat-embed-core:$tomcat8_version"
   compile "org.apache.tomcat.embed:tomcat-embed-el:$tomcat8_version"
   compile "org.apache.tomcat.embed:tomcat-embed-jasper:$tomcat8_version"
-  compile "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcat8_version"
+  if (VersionNumber.parse(tomcat8_version) <= VersionNumber.parse('8.5.2'))
+    compile "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcat8_version"
   compile "org.apache.tomcat.embed:tomcat-embed-websocket:$tomcat8_version"
   // this fixes incorrect dependency of tomcat-8.0.9 on ecj-4.4RC4
   if(tomcat8_version == '8.0.9')

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
@@ -10,6 +10,7 @@ package org.akhikhl.gretty
 
 import org.apache.commons.lang.SystemUtils
 import org.gradle.api.Project
+import org.gradle.util.VersionNumber
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -167,7 +168,8 @@ class ServletContainerConfig {
             force "org.apache.tomcat.embed:tomcat-embed-core:$tomcat8_version"
             force "org.apache.tomcat.embed:tomcat-embed-el:$tomcat8_version"
             force "org.apache.tomcat.embed:tomcat-embed-jasper:$tomcat8_version"
-            force "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcat8_version"
+            if (VersionNumber.parse(tomcat8_version) <= VersionNumber.parse('8.5.2'))
+              force "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcat8_version"
             force "org.apache.tomcat.embed:tomcat-embed-websocket:$tomcat8_version"
             // this fixes incorrect dependency of tomcat-8.0.9 on ecj-4.4RC4
             if(tomcat8_version == '8.0.9')


### PR DESCRIPTION
Due to the following thread:
http://tomcat.10.x6.nabble.com/ANN-Apache-Tomcat-8-5-3-available-td5051828.html

Fixes https://github.com/akhikhl/gretty/pull/369

PR copied from https://github.com/akhikhl/gretty/pull/373