### PR TITLE
Fixed resource-loading of default logback config file

### DIFF
--- a/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
+++ b/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
@@ -62,7 +62,7 @@ final class Runner {
       logbackConfigText = new File(serverParams.logbackConfigFile).getText('UTF-8')
     }
     else
-      logbackConfigText = this.getClass().getResourceAsStream('/grettyRunnerLogback.groovy').getText('UTF-8')
+      logbackConfigText = Runner.class.getResourceAsStream('/grettyRunnerLogback.groovy').getText('UTF-8')
     Binding binding = new Binding()
     binding.loggingLevel = stringToLoggingLevel(serverParams.loggingLevel)
     binding.consoleLogEnabled = Boolean.valueOf(serverParams.consoleLogEnabled == null ? true : serverParams.consoleLogEnabled)


### PR DESCRIPTION
Fixed #13.  See notes in issue about how Groovy can see odd results for `this.getClass()`.