### PR TITLE
Exclude Jetty7/8 in testAll when running JDK9. Fixed #15.

### DIFF
--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
@@ -3,6 +3,7 @@ package org.akhikhl.gretty.internal.integrationTests
 import org.akhikhl.gretty.AppAfterIntegrationTestTask
 import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 import org.akhikhl.gretty.ServletContainerConfig
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.testing.Test
@@ -73,6 +74,12 @@ class IntegrationTestPlugin extends BasePlugin {
       if(!integrationTestContainers)
         // excluding jetty9.3/4 tests because of login bug
         integrationTestContainers = ServletContainerConfig.getConfigNames() - ['jetty9.3', 'jetty9.4']
+
+      if(JavaVersion.current().isJava9Compatible()) {
+        // excluding jetty7 and jetty8 under JDK9, can no longer compile JSPs to default 1.5 target,
+        // see https://github.com/gretty-gradle-plugin/gretty/issues/15
+        integrationTestContainers -= ['jetty7', 'jetty8']
+      }
 
       integrationTestContainers.each { String container ->
 


### PR DESCRIPTION
Another change towards a JDK9 `testAll` clean run, although that still seems a way off.

In theory I think here we could add some Jetty directives to up the requested class compat to 6, but it also seems reasonable to exclude Jetty 7&8 now when compiling/testing with JDK9.