### PR TITLE
Removed tag-triggered build from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,3 @@ deploy:
     on:
       branch: master
       jdk: oraclejdk8
-  - provider: script
-    skip_cleanup: true
-    script: ./gradlew bintrayUpload -PbintrayUser=${BINTRAY_USER} -PbintrayKey=${BINTRAY_KEY} -PbintrayRepo=${BINTRAY_REPO} -PbintrayPackage=${BINTRAY_PACKAGE}
-    on:
-      tags: true
-      jdk: oraclejdk8


### PR DESCRIPTION
Starting to unpack the release-procedure.  I see this tag-triggered build in Travis, but it fails or would fail for two reasons:

1. The tag will be for a release build and it looks like these are run locally, so the Travis build fails because the artifact of that version is already deployed.
1. Travis doesn't have all of the secrets it needs to GPG sign the build.  Probably fair enough - Bintray can hold both the secret key and passphase, but who really wants to do that.  The current build script can look for a passed `project.bintrayKeyPhrase`, but I don't think Travis is currently set-up to pass that as environment like some of the other keys.

Last couple of tag builds fail on Travis due to duplicates, so the tag is already released:

- https://travis-ci.org/akhikhl/gretty/jobs/197166343#L1527
- https://travis-ci.org/akhikhl/gretty/jobs/210956003#L1516
- https://travis-ci.org/akhikhl/gretty/jobs/245241039#L2189

So removing this Travis build.