### PR TITLE
Run integrationTests/testAll on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,13 @@ before_script:
   - sleep 3 # give xvfb some time to start
 install:
   - true
-script: ./gradlew build
+script:
+  - |
+    if [[ "${TRAVIS_JDK_VERSION}" == "oraclejdk8" && ( "${TRAVIS_BRANCH}" == "master" || "${TRAVIS_EVENT_TYPE}" == "pull_request" || "${TRAVIS_EVENT_TYPE}" == "cron" ) ]]; then
+      ./gradlew -PgeckoDriverPlatform=linux64 -PgeckoDriverVersion=0.20.0 build testAll
+    else
+      ./gradlew build
+    fi
 env:
   global:
     - secure: "yP1LR0IRe1CHjKKq21bAxTU/lLTFjmtx0Gaem0Ttl0HTvK72cyZQ3zs1VgGZfnsqjtDmT0KCipk7j0/S6kf4TxLE8esXT3t9twRO2hTpBO0AhJmvgiaLtOkrQx68I+LamUpVpkYod69yhvVHjJxxoBM8h6EgxricLD0cboO8l/hLFdBODHkUs+07olQyeiuXJ5xgdviC7jmEO5XhdIb2kVfXmdcCHAjw3ow4h/02gw0F6gt0fsPxNlaLqWr1hnmop1bcRJ02llBBf4odd7IZHYBtclrfYrKB1ID6VOra0QscEbTuCcZaSNCNPzt/xMuyOCDFZlKCatYpXo+lDqTASa8Np+Ck9yBpbcBED3NGyadbv9ASbKZOHc65n9drINSzcX3w50MaELxeypNMjQ9W9KghXKdCtAwTVe2OmzOS283OmBGz8PNOI1/t3+rYfqE5SkPiQDSRfJtiZqHDEu7TrxfdoumDQPw/znvtcW2MPrCQpxCnKhseT3EJ1SNJVGFzkcbyAfs90uW/fyWYVNhcfP4LgM4gDy4Ggh/5PTEAXQ9BWvVJ4fSCkZfgMriS9MmgI7054V/PgmZN1Io2UmYK3Nw77u3OpYr4Uz1PlMsWE5ilB09+pDeUZmDLzSF19Z8UV8wRsafYFaO8e9wK0aCtUHfxAbtbpF4daJxqT6+7LVw="

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
+install:
+  - true
 script: ./gradlew build
 env:
   global:

--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,19 @@ task testAllIntegrationTests(type: GradleBuild) {
   dependsOn buildIntegrationTests
   dir = file('integrationTests')
   tasks = [ 'testAll' ]
+  startParameter.projectProperties = [:]
+  if (project.hasProperty('geckoDriverPlatform')) {
+    startParameter.projectProperties.put('geckoDriverPlatform', project.geckoDriverPlatform)
+  }
+  if (project.hasProperty('geckoDriverVersion')) {
+    startParameter.projectProperties.put('geckoDriverVersion', project.geckoDriverVersion)
+  }
+  if (project.hasProperty('seleniumVersion')) {
+    startParameter.projectProperties.put('seleniumVersion', project.seleniumVersion)
+  }
+  if (project.hasProperty('gebVersion')) {
+    startParameter.projectProperties.put('gebVersion', project.gebVersion)
+  }
   project.tasks.testAll.finalizedBy it
   onlyIf { !project.tasks.testAll.getState().getFailure() }
 }

--- a/integrationTests/buildSrc/gradle.properties
+++ b/integrationTests/buildSrc/gradle.properties
@@ -1,5 +1,6 @@
 rootProjectName = gretty-integrationTests-buildsrc
 geckoDriverVersion = 0.17.0
+geckoDriverPlatform = macos
 gradle_download_task_version = 3.1.1
 commons_configuration_version = 1.10
 gebVersion=1.1.1

--- a/integrationTests/buildSrc/gradle.properties
+++ b/integrationTests/buildSrc/gradle.properties
@@ -3,6 +3,6 @@ geckoDriverVersion = 0.17.0
 geckoDriverPlatform = macos
 gradle_download_task_version = 3.1.1
 commons_configuration_version = 1.10
-gebVersion=1.1.1
-seleniumVersion=3.4.0
+gebVersion=2.1
+seleniumVersion=3.11.0
 # other properties are copied by gradle script from higher-level projects

--- a/integrationTests/buildSrc/gretty-integrationTest/build.gradle
+++ b/integrationTests/buildSrc/gretty-integrationTest/build.gradle
@@ -18,6 +18,7 @@ def projectProps = [
   buildOrigin: ('hostname'.execute().text.trim()),
   gebVersion: project.gebVersion,
   geckoDriverVersion: project.geckoDriverVersion,
+  geckoDriverPlatform: project.geckoDriverPlatform,
   groovy_version: project.groovy_version,
   seleniumVersion: project.seleniumVersion,
   spock_version: project.spock_version

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
@@ -76,7 +76,7 @@ class BasePlugin implements Plugin<Project> {
   }
 
   protected void configureRootProjectProperties(Project project) {
-    for(prop in ['gebVersion', 'geckoDriverVersion', 'groovy_version', 'seleniumVersion', 'spock_version'])
+    for(prop in ['gebVersion', 'geckoDriverVersion', 'geckoDriverPlatform', 'groovy_version', 'seleniumVersion', 'spock_version'])
       if(!project.hasProperty(prop))
         project.ext[prop] = ProjectProperties.getString(prop)
   }

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
@@ -119,7 +119,7 @@ class IntegrationTestPlugin extends BasePlugin {
   protected void configureRootProjectProperties(Project project) {
     super.configureRootProjectProperties(project)
     if(!project.hasProperty('geckoDriverArchiveFileName'))
-      project.ext.geckoDriverArchiveFileName = "geckodriver-v${project.geckoDriverVersion}-macos.tar.gz"
+      project.ext.geckoDriverArchiveFileName = "geckodriver-v${project.geckoDriverVersion}-${project.geckoDriverPlatform}.tar.gz"
     if(!project.hasProperty('geckoDriverDownloadUrl'))
       project.ext.geckoDriverDownloadUrl = "https://github.com/mozilla/geckodriver/releases/download/v${project.geckoDriverVersion}/${project.geckoDriverArchiveFileName}"
   }

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/resources/org/akhikhl/gretty/internal/integrationTests/project.properties
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/resources/org/akhikhl/gretty/internal/integrationTests/project.properties
@@ -6,6 +6,7 @@ buildUser=@buildUser@
 buildOrigin=@buildOrigin@
 gebVersion=@gebVersion@
 geckoDriverVersion=@geckoDriverVersion@
+geckoDriverPlatform=@geckoDriverPlatform@
 groovy_version=@groovy_version@
 seleniumVersion=@seleniumVersion@
 spock_version=@spock_version@

--- a/integrationTests/config/gebConfig/GebConfig.groovy
+++ b/integrationTests/config/gebConfig/GebConfig.groovy
@@ -1,7 +1,11 @@
 import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.firefox.FirefoxProfile
+import org.openqa.selenium.firefox.FirefoxOptions
 
+FirefoxOptions options = new FirefoxOptions()
+options.setProfile(new FirefoxProfile(new File(System.getProperty('firefox.profile.path'))))
+options.setHeadless(true)
 driver = {
   // we pass profile with trusted localhost ssl certificate
-  new FirefoxDriver(new FirefoxProfile(new File(System.getProperty('firefox.profile.path'))))
+  new FirefoxDriver(options)
 }

--- a/integrationTests/websocket/build.gradle
+++ b/integrationTests/websocket/build.gradle
@@ -8,6 +8,7 @@ gretty {
 
 dependencies {
   compile 'org.webjars:jquery:2.1.1'
+  compile 'org.webjars:sockjs-client:0.3.4-1'
 }
 
 defineIntegrationTest()

--- a/integrationTests/websocket/src/main/webapp/index.html
+++ b/integrationTests/websocket/src/main/webapp/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <h1>Websocket chat</h1>
-    <div><a id="openNewChat" href="#" target="_blank">Open new chat</a></div>
+    <div><a id="openNewChat" href="#" target="otherBrowser">Open new chat</a></div>
     <textarea id="chat-content" style="width: 500px; height: 300px"></textarea><br/>
     <input type="text" id="username" placeholder="Choose username"/>
     <input type="text" id="message" placeholder="Enter chat message"/>


### PR DESCRIPTION
This changeset allows the full `testAll` `integrationTests` suite to be run on Linux/Travis.  This should improve pre-release testing since we no longer need to rely on running the integration tests solely on a developer's MacOS environment.

Started by noticing that the Gecko driver was hard-coded to the `macos` dist, so externalized this, retaining the current default.  Due to the way `integrationTests` is called as a separate Gradle project, I needed to provide a mechanism to allow dist/version overrides to be plumbed-through, as these properties are in `integrationTests`.

The remainder is mostly solving issues found with running (headless?) on Linux/Travis.  I needed to update Selenium and Geb.  Also needed to update the Gecko driver, but the equivalent version caused problems for me on MacOS, so I retained the existing version there.  The Travis launch contains the property-overrides.

For now, this will cause the JDK8 build for master, any pull-request or any Travis-cron build to run the full `testAll` suite.

On configurations and events where this is active, you'll see the JDK8 build time jump from around 5 minutes to around 35 minutes as `testAll` runs and launches all the browser-automation tests.

Fixes #14.
