### PR TITLE
testAll split/parallelisation by-container with testAllContainers/TEST_ALL_CONTAINERS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,22 @@
 language: groovy
-jdk:
-  - openjdk7
-  - oraclejdk8
-  - oraclejdk9
+matrix:
+  include:
+  - jdk: openjdk7
+  - jdk: oraclejdk9
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['jetty7']"
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['jetty8']"
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['jetty9']"
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['tomcat7']"
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['tomcat8']"
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['tomcat85']"
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['tomcat9']"
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:
@@ -27,7 +41,7 @@ install:
 script:
   - |
     if [[ "${TRAVIS_JDK_VERSION}" == "oraclejdk8" && ( "${TRAVIS_BRANCH}" == "master" || "${TRAVIS_EVENT_TYPE}" == "pull_request" || "${TRAVIS_EVENT_TYPE}" == "cron" ) ]]; then
-      ./gradlew -PgeckoDriverPlatform=linux64 -PgeckoDriverVersion=0.20.0 build testAll
+      ./gradlew -PgeckoDriverPlatform=linux64 -PgeckoDriverVersion=0.20.0 -PtestAllContainers=${TEST_ALL_CONTAINERS} build testAll
     else
       ./gradlew build
     fi

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,9 @@ task testAllIntegrationTests(type: GradleBuild) {
   if (project.hasProperty('gebVersion')) {
     startParameter.projectProperties.put('gebVersion', project.gebVersion)
   }
+  if (project.hasProperty('testAllContainers')) {
+    startParameter.projectProperties.put('testAllContainers', project.testAllContainers)
+  }
   project.tasks.testAll.finalizedBy it
   onlyIf { !project.tasks.testAll.getState().getFailure() }
 }

--- a/integrationTests/buildSrc/gradle.properties
+++ b/integrationTests/buildSrc/gradle.properties
@@ -5,4 +5,7 @@ gradle_download_task_version = 3.1.1
 commons_configuration_version = 1.10
 gebVersion=2.1
 seleniumVersion=3.11.0
+
+testAllContainers=
+
 # other properties are copied by gradle script from higher-level projects

--- a/integrationTests/buildSrc/gretty-integrationTest/build.gradle
+++ b/integrationTests/buildSrc/gretty-integrationTest/build.gradle
@@ -21,11 +21,13 @@ def projectProps = [
   geckoDriverPlatform: project.geckoDriverPlatform,
   groovy_version: project.groovy_version,
   seleniumVersion: project.seleniumVersion,
-  spock_version: project.spock_version
+  spock_version: project.spock_version,
+  testAllContainers: project.testAllContainers
 ]
 
 processResources {
   inputs.properties projectProps
+  outputs.upToDateWhen{ false }
   filesMatching('**/project.properties') {
     filter ReplaceTokens, tokens: projectProps
   }

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
@@ -76,9 +76,11 @@ class BasePlugin implements Plugin<Project> {
   }
 
   protected void configureRootProjectProperties(Project project) {
-    for(prop in ['gebVersion', 'geckoDriverVersion', 'geckoDriverPlatform', 'groovy_version', 'seleniumVersion', 'spock_version'])
-      if(!project.hasProperty(prop))
+    for(prop in ['gebVersion', 'geckoDriverVersion', 'geckoDriverPlatform', 'groovy_version', 'seleniumVersion', 'spock_version', 'testAllContainers']) {
+      if(!project.hasProperty(prop)) {
         project.ext[prop] = ProjectProperties.getString(prop)
+      }
+    }
   }
 
   protected void configureRootProjectTasksAfterEvaluate(Project project) {

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
@@ -113,6 +113,7 @@ class BasePlugin implements Plugin<Project> {
 
     applyPlugins(project)
     applyPluginsToRootProject(project.rootProject)
+    configureRootProjectProperties(project.rootProject)
     configureRepositories(project)
     configureExtensions(project)
     configureSourceSets(project)
@@ -121,9 +122,7 @@ class BasePlugin implements Plugin<Project> {
     project.afterEvaluate {
 
       configurePublications(project)
-      configureRootProjectProperties(project.rootProject)
       configureRootProjectTasksAfterEvaluate(project.rootProject)
-
       configureDependencies(project)
       configureTasksAfterEvaluate(project)
 

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
@@ -27,6 +27,10 @@ class FarmIntegrationTestPlugin extends BasePlugin {
         // excluding jetty9.3/4 tests because of login bug
         integrationTestContainers = ServletContainerConfig.getConfigNames() - ['jetty9.3', 'jetty9.4']
 
+      if(project.hasProperty('testAllContainers') && project.testAllContainers) {
+        integrationTestContainers.retainAll(Eval.me(project.testAllContainers))
+      }
+
       integrationTestContainers.each { container ->
 
         project.farms.farm container, {

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
@@ -81,6 +81,10 @@ class IntegrationTestPlugin extends BasePlugin {
         integrationTestContainers -= ['jetty7', 'jetty8']
       }
 
+      if(project.hasProperty('testAllContainers') && project.testAllContainers) {
+        integrationTestContainers.retainAll(Eval.me(project.testAllContainers))
+      }
+
       integrationTestContainers.each { String container ->
 
         project.task('integrationTest_' + container, type: Test) { thisTask ->

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/resources/org/akhikhl/gretty/internal/integrationTests/project.properties
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/resources/org/akhikhl/gretty/internal/integrationTests/project.properties
@@ -10,3 +10,4 @@ geckoDriverPlatform=@geckoDriverPlatform@
 groovy_version=@groovy_version@
 seleniumVersion=@seleniumVersion@
 spock_version=@spock_version@
+testAllContainers=@testAllContainers@


### PR DESCRIPTION
First-pass at changing the Travis build for integration-tests `testAll` to be a matrix of JDK x ServletContainer (for JDK8, other JDKs currently skip `testAll`).  This parallelises the build and avoids long builds and Travis timeouts whilst retaining best coverage.

Note the approach here for new build prop `testAllContainers` is that it is applied as `retainAll` on the existing collection of containers to run for a test.  This rather than replacing, as some tests are already self-limiting e.g. might exclude `jetty7`, so when you want to test only `jetty7` by applying set intersection you won't run additional, unwanted tests.

Main feedback requested - the variable name isn't great ... any suggestions for improvements, or is it OK ... I thought maybe `testOnlyContainers` might be better?

Note there are plenty of rough edges remaining including:

* Jetty 9.2 seems to be the only Jetty 9 running for now - we should ensure 9.4 runs.
* Some tests just run Jetty 9.2 regardless of config ... might be valid, need to check.

This PR should demonstrate the change itself in Travis - previous test run over in my fork: https://travis-ci.org/javabrett/gretty/builds/373003587 .  One of the builds failed originally first-time there and had to be restarted and passed, so there is at least one fragility in the test-framework running on Travis, or a bug.

Fixes #39.