### PR TITLE
Remove JDK7 support and references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: groovy
 matrix:
   include:
-  - jdk: openjdk7
   - jdk: oraclejdk9
   - jdk: oraclejdk8
     env: TEST_ALL_CONTAINERS="['jetty7']"
@@ -27,11 +26,6 @@ before_install:
   - chmod +x gradlew
   - sudo apt-get -qq update
   - sudo apt-get install -y zip curl locate libbcprov-java
-  - |
-    sudo ln -s /usr/share/java/bcprov.jar /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext/bcprov.jar \
-    && sudo awk -F . -v OFS=. 'BEGIN{n=2}/^security\.provider/ {split($3, posAndEquals, "=");$3=n++"="posAndEquals[2];print;next} 1' /etc/java-7-openjdk/security/java.security > /tmp/java.security \
-    && sudo echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" >> /tmp/java.security \
-    && sudo mv /tmp/java.security /etc/java-7-openjdk/security/java.security
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ You can learn about all Gretty features in [online documentation](https://gretty
 
 #### System requirements
 
-Gretty requires JDK7, JDK8 or JDK9 and Gradle 1.10 or newer (Gradle 4.0 is highly recommended!).
+Gretty requires JDK8 or JDK9 and Gradle 1.10 or newer (Gradle 4.0 is highly recommended!).
 
-Since version 2.0.0 Gretty no longer supports JDK6.
+- Since version 2.0.0 Gretty no longer supports JDK6.
+- Since version 3.0.0 Gretty no longer supports JDK7.
 
 #### Availability
 

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,10 @@
 
 [![logo](https://gretty-gradle-plugin.github.io/gretty-doc/images/gretty_logo.png "gretty logo")](https://github.com/gretty-gradle-plugin/gretty)
 
+### Version 3.0.0
+
+* Support for JDK7 has been removed.
+
 ### Version 2.2.0
 
 * Bumped default Tomcat 9 version to 9.0.6 (was 9.0.5).

--- a/common.gradle
+++ b/common.gradle
@@ -29,8 +29,8 @@ afterEvaluate {
     testCompile "org.spockframework:spock-core:${spock_version}"
   }
 
-  sourceCompatibility = '1.7'
-  targetCompatibility = '1.7'
+  sourceCompatibility = '1.8'
+  targetCompatibility = '1.8'
 
   task sourcesJar(type: Jar, dependsOn: classes, description: 'Creates sources jar') {
     classifier = 'sources'

--- a/libs/gretty/build.gradle
+++ b/libs/gretty/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     exclude group: 'ch.qos.logback', module: 'logback-classic'
   }
   compile "org.springframework.boot:spring-boot-loader-tools:${springBootVersion}"
-  // jetty-util provides org.eclipse.jetty.util.Scanner. Must use version 8 to stay compatible with JDK6.
   compile "org.eclipse.jetty:jetty-util:$jetty8_version"
   compile gradleApi()
 }


### PR DESCRIPTION
Now that `master` is `3.x`, kicking-off the platform-support deprecations/removals with JDK7, which is a fairly small change.