### PR TITLE
Make the default servlet container jetty9.4 (Jetty 9.4)

### DIFF
--- a/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/ServerConfig.groovy
+++ b/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/ServerConfig.groovy
@@ -89,7 +89,7 @@ class ServerConfig {
   static ServerConfig getDefaultServerConfig(String serverName) {
     ServerConfig result = new ServerConfig()
     result.jvmArgs = []
-    result.servletContainer = 'jetty9'
+    result.servletContainer = 'jetty9.4'
     result.managedClassReload = false
     result.httpEnabled = true
     result.httpsEnabled = false

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
@@ -302,7 +302,7 @@ class ServletContainerConfig {
   }
 
   static getConfig(servletContainer) {
-    servletContainer = servletContainer ?: 'jetty9'
+    servletContainer = servletContainer ?: 'jetty9.4'
     def result = configs[servletContainer.toString()]
     if(!result)
       throw new Exception("Unsupported servlet container: $servletContainer")
@@ -326,7 +326,7 @@ class ServletContainerConfig {
     }
     if(compatibleConfigEntry)
       return compatibleConfigEntry.key
-    String defaultJettyServletContainer = 'jetty9'
+    String defaultJettyServletContainer = 'jetty9.4'
     log.warn 'Cannot find jetty container with compatible servlet-api to {}, defaulting to {}', servletContainer, defaultJettyServletContainer
     defaultJettyServletContainer
   }


### PR DESCRIPTION
Another small compatibility change for 3.x - currently the default `servletContainer` (when none or bad supplied) is `jetty9`, which means Jetty 9.2.  This change makes it Jetty 9.4, with the exact runtime version taken from `jetty94_version` which currently defaults to `9.4.10.v20180503`.

There's actually a couple of rough edges with Jetty 9.4 support, but I think we just need to accept that and work through them for 3.x - need to be on the latest Jetty branch by-default.

Testing - `./gradlew build` then cd to `integrationTests/helloGretty` and run `../gradlew appRunWar`.  That project has no `servletContainer` in `build.gradle` and so will move from Jetty 9.2 to 9.4 with this change.