### PR TITLE
Gradle 4.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ task cleanIntegrationTests(type: GradleBuild) {
 }
 
 wrapper {
-    gradleVersion = '4.7'
+    gradleVersion = '4.8'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionSha256Sum=da9600da2a28a43f5f77364deecbb9b01c1ddb7d3ecafe1d5c93bcd8a8059ab1
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integrationTests/build.gradle
+++ b/integrationTests/build.gradle
@@ -37,6 +37,6 @@ allprojects {
 }
 
 wrapper {
-  gradleVersion = '4.7'
+  gradleVersion = '4.8'
   distributionType = Wrapper.DistributionType.ALL
 }

--- a/integrationTests/buildSrc/settings.gradle
+++ b/integrationTests/buildSrc/settings.gradle
@@ -1,2 +1,5 @@
 rootProject.name = rootProjectName
 include 'gretty-integrationTest'
+
+enableFeaturePreview('STABLE_PUBLISHING')
+

--- a/integrationTests/gradle/wrapper/gradle-wrapper.properties
+++ b/integrationTests/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionSha256Sum=da9600da2a28a43f5f77364deecbb9b01c1ddb7d3ecafe1d5c93bcd8a8059ab1
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integrationTests/settings.gradle
+++ b/integrationTests/settings.gradle
@@ -42,3 +42,6 @@ include 'spring-boot-farm-secure:spring-boot-app'
 include 'spring-boot-farm-secure:spring-boot-webservice'
 include 'spring-boot-farm-secure:jee-webservice'
 include 'springBootWebSocket'
+
+enableFeaturePreview('STABLE_PUBLISHING')
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,3 +23,6 @@ if (JavaVersion.current().isJava8Compatible()) {
 include 'libs:gretty-spock'
 include 'libs:gretty-springboot'
 include 'libs:gretty-starter'
+
+enableFeaturePreview('STABLE_PUBLISHING')
+


### PR DESCRIPTION
* Upgrades to Gradle 4.8 ([release notes](https://docs.gradle.org/4.8/release-notes.html))
* Enable stable publishing feature ahead of Gradle 5.0 release