### PR TITLE
Run integrationTests for Jetty 9.3 and 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
   - jdk: oraclejdk8
     env: TEST_ALL_CONTAINERS="['jetty9']"
   - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['jetty9.3']"
+  - jdk: oraclejdk8
+    env: TEST_ALL_CONTAINERS="['jetty9.4']"
+  - jdk: oraclejdk8
     env: TEST_ALL_CONTAINERS="['tomcat7']"
   - jdk: oraclejdk8
     env: TEST_ALL_CONTAINERS="['tomcat8']"

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
@@ -24,8 +24,7 @@ class FarmIntegrationTestPlugin extends BasePlugin {
       farmIntegrationTestAllContainersTask = project.task('farmIntegrationTestAllContainers')
 
       if(!integrationTestContainers)
-        // excluding jetty9.3/4 tests because of login bug
-        integrationTestContainers = ServletContainerConfig.getConfigNames() - ['jetty9.3', 'jetty9.4']
+        integrationTestContainers = ServletContainerConfig.getConfigNames()
 
       if(project.hasProperty('testAllContainers') && project.testAllContainers) {
         integrationTestContainers.retainAll(Eval.me(project.testAllContainers))

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
@@ -16,18 +16,24 @@ class FarmIntegrationTestPlugin extends BasePlugin {
     project.ext.defineFarmIntegrationTestAllContainers = { Collection integrationTestContainers = null, Closure configureFarm ->
 
       def farmIntegrationTestAllContainersTask = project.tasks.findByName('farmIntegrationTestAllContainers')
-      if(farmIntegrationTestAllContainersTask)
+      if (farmIntegrationTestAllContainersTask)
         return farmIntegrationTestAllContainersTask
 
       project.ext.defineIntegrationTestAllContainers(integrationTestContainers)
 
       farmIntegrationTestAllContainersTask = project.task('farmIntegrationTestAllContainers')
 
-      if(!integrationTestContainers)
+      if (!integrationTestContainers)
         integrationTestContainers = ServletContainerConfig.getConfigNames().collect() // returns immutable and we want to filter later
 
-      if(project.hasProperty('testAllContainers') && project.testAllContainers) {
+      if (project.hasProperty('testAllContainers') && project.testAllContainers) {
         integrationTestContainers.retainAll(Eval.me(project.testAllContainers))
+      }
+
+      // farmSecure tests not working on Jetty 9.3 and 9.4, see https://github.com/gretty-gradle-plugin/gretty/issues/67
+      if (project.path.startsWith(':farmSecure')) {
+        println "Excluding farmSecure tests from Jetty 9.3/9.4, see https://github.com/gretty-gradle-plugin/gretty/issues/67 ."
+        integrationTestContainers -= ['jetty9.3', 'jetty9.4']
       }
 
       integrationTestContainers.each { container ->

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/FarmIntegrationTestPlugin.groovy
@@ -24,7 +24,7 @@ class FarmIntegrationTestPlugin extends BasePlugin {
       farmIntegrationTestAllContainersTask = project.task('farmIntegrationTestAllContainers')
 
       if(!integrationTestContainers)
-        integrationTestContainers = ServletContainerConfig.getConfigNames()
+        integrationTestContainers = ServletContainerConfig.getConfigNames().collect() // returns immutable and we want to filter later
 
       if(project.hasProperty('testAllContainers') && project.testAllContainers) {
         integrationTestContainers.retainAll(Eval.me(project.testAllContainers))

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
@@ -72,7 +72,7 @@ class IntegrationTestPlugin extends BasePlugin {
       integrationTestAllContainersTask = project.task('integrationTestAllContainers')
 
       if(!integrationTestContainers)
-        integrationTestContainers = ServletContainerConfig.getConfigNames()
+        integrationTestContainers = ServletContainerConfig.getConfigNames().collect() // returns immutable and we want to filter later
 
       if(JavaVersion.current().isJava9Compatible()) {
         // excluding jetty7 and jetty8 under JDK9, can no longer compile JSPs to default 1.5 target,

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
@@ -72,8 +72,7 @@ class IntegrationTestPlugin extends BasePlugin {
       integrationTestAllContainersTask = project.task('integrationTestAllContainers')
 
       if(!integrationTestContainers)
-        // excluding jetty9.3/4 tests because of login bug
-        integrationTestContainers = ServletContainerConfig.getConfigNames() - ['jetty9.3', 'jetty9.4']
+        integrationTestContainers = ServletContainerConfig.getConfigNames()
 
       if(JavaVersion.current().isJava9Compatible()) {
         // excluding jetty7 and jetty8 under JDK9, can no longer compile JSPs to default 1.5 target,

--- a/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
+++ b/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
@@ -28,22 +28,25 @@ class JettyServerConfigurer {
   protected void configureWithBaseResource(Map webapp, context) {
 
     URL contextConfigFile = getContextConfigFile(context.baseResource, params.servletContainerId)
-    if(!contextConfigFile && webapp.contextConfigFile)
+    if (!contextConfigFile && webapp.contextConfigFile)
       contextConfigFile = new File(webapp.contextConfigFile).toURI().toURL()
     configurer.applyContextConfigFile(context, contextConfigFile)
 
     String realm = webapp.realm ?: params.realm
-    URL realmConfigFile = getRealmFile(context.baseResource, params.servletContainerId)
-    if(!realmConfigFile) {
-      if(webapp.realmConfigFile) {
-        realmConfigFile = new File(webapp.realmConfigFile).canonicalFile.toURI().toURL()
+    File realmConfigFile
+    URL realmConfigFileUrl = getRealmFile(context.baseResource, params.servletContainerId)
+    if (realmConfigFileUrl) {
+      realmConfigFile = new File(realmConfigFileUrl.toURI()).canonicalFile
+    } else {
+      if (webapp.realmConfigFile) {
+        realmConfigFile = new File(webapp.realmConfigFile).canonicalFile
       }
-      else if(params.realmConfigFile) {
-        realmConfigFile = new File(params.realmConfigFile).canonicalFile.toURI().toURL()
+      else if (params.realmConfigFile) {
+        realmConfigFile = new File(params.realmConfigFile).canonicalFile
       }
     }
-    if(realm && realmConfigFile) {
-      if(context.securityHandler.loginService == null) {
+    if (realm && realmConfigFile) {
+      if (context.securityHandler.loginService == null) {
         log.info 'Configuring {} with realm \'{}\', {}', context.contextPath, realm, realmConfigFile
         configurer.configureSecurity(context, realm, realmConfigFile.toString(), params.singleSignOn ?: false)
       } else

--- a/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -203,7 +203,7 @@ class JettyConfigurerImpl implements JettyConfigurer {
     context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') }.collect { new File(it) })
     context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.join(';'))
     context.setInitParameter('org.eclipse.jetty.servlet.Default.useFileMappedBuffer', serverParams.productMode ? 'true' : 'false')
-    context.setAttribute('org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern',
+    context.setAttribute(WebInfConfiguration.CONTAINER_JAR_PATTERN,
         '.*/[^/]*servlet-api-[^/]*\\.jar$|.*/javax.servlet.jsp.jstl-.*\\.jar$|.*/[^/]*taglibs.*\\.jar$');
     FilteringClassLoader classLoader = new FilteringClassLoader(context)
     classLoader.addServerClass('ch.qos.logback.')

--- a/libs/gretty-runner/src/main/resources/grettyRunnerLogback.groovy
+++ b/libs/gretty-runner/src/main/resources/grettyRunnerLogback.groovy
@@ -51,4 +51,6 @@ logger 'org.eclipse.jetty', WARN
 
 logger 'org.eclipse.jetty.annotations.AnnotationConfiguration', ERROR
 
+logger 'org.eclipse.jetty.annotations.AnnotationParser', ERROR
+
 logger 'org.eclipse.jetty.util.component.AbstractLifeCycle', ERROR


### PR DESCRIPTION
This puts Jetty 9.3 and 9.4 `integrationTests` execution into the Travis matrix, with the required fixes and exclusions in-place.

Fixes #61.