### PR TITLE
Update Bouncy Castle to 1.60

### DIFF
--- a/libs/gretty-core/build.gradle
+++ b/libs/gretty-core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   compile 'commons-configuration:commons-configuration:1.10'
   compile 'commons-io:commons-io:2.4'
   compile 'org.apache.commons:commons-lang3:3.3.2'
-  compile 'org.apache.servicemix.bundles:org.apache.servicemix.bundles.bcprov-jdk16:1.46_3'
+  compile 'org.bouncycastle:bcprov-jdk15on:1.60'
   compile "org.springframework.boot:spring-boot-devtools:$springBootVersion"
 }
 

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/CertificateGenerator.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/CertificateGenerator.groovy
@@ -8,6 +8,7 @@
  */
 package org.akhikhl.gretty
 
+import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.Security
 import java.security.SecureRandom
@@ -15,7 +16,7 @@ import java.security.cert.Certificate
 import org.apache.commons.lang3.RandomStringUtils
 import org.bouncycastle.jce.X509Principal
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.jce.provider.asymmetric.ec.KeyPairGenerator
+import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi
 import org.bouncycastle.x509.X509V3CertificateGenerator
 import org.gradle.api.Project
 import org.slf4j.Logger
@@ -57,7 +58,7 @@ class CertificateGenerator {
     if(!keystoreFile.exists() || !certFile.exists() || !propertiesFile.exists()) {
       dir.mkdirs()
       log.info 'Generating RSA key'
-      def keyPairGenerator = KeyPairGenerator.getInstance('RSA', 'BC')
+      KeyPairGenerator keyPairGenerator = KeyPairGeneratorSpi.getInstance('RSA', 'BC')
       keyPairGenerator.initialize(1024, new SecureRandom())
       def KPair = keyPairGenerator.generateKeyPair()
       log.info 'Generating self-signed X.509 certificate'


### PR DESCRIPTION
Bouncy Castle 1.47 introduces a bunch of API changes that break compatibility ([see here](http://www.bouncycastle.org/wiki/display/JA1/Porting+from+earlier+BC+releases+to+1.47+and+later)).

This can create classpath problems between Gretty and other Gradle plugins. Keeping Bouncy Castle up to date can hopefully make Gretty play nice with the latest versions of other plugins.