### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ install:
 script:
   - |
     set -e
-    ./gradlew build
+    ./gradlew build --scan
     if [[ ! -z $TEST_ALL_CONTAINERS && ( -z $TEST_ALL || "${TRAVIS_REPO_SLUG}" == "gretty-gradle-plugin/gretty" ) ]]; then
       ./gradlew wrapper --gradle-version ${TEST_ALL_GRADLE_VERSION} --distribution-type all
       cd integrationTests
-      ../gradlew -PgeckoDriverPlatform=linux64 -PgeckoDriverVersion=0.20.0 -PtestAllContainers=${TEST_ALL_CONTAINERS} testAll
+      ../gradlew -PgeckoDriverPlatform=linux64 -PgeckoDriverVersion=0.20.0 -PtestAllContainers=${TEST_ALL_CONTAINERS} testAll --scan
       cd ..
     fi
     set +e

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,14 @@ buildscript {
 import groovyx.net.http.ContentType
 
 plugins {
+  id 'com.gradle.build-scan' version '1.16'
   id 'base'
   id 'maven-publish'
+}
+
+buildScan {
+  termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+  termsOfServiceAgree = 'yes'
 }
 
 apply plugin: 'com.jfrog.artifactory'

--- a/integrationTests/build.gradle
+++ b/integrationTests/build.gradle
@@ -32,6 +32,15 @@ buildscript {
   }
 }
 
+plugins {
+  id 'com.gradle.build-scan' version '1.16'
+}
+
+buildScan {
+  termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+  termsOfServiceAgree = 'yes'
+}
+
 allprojects {
   version = rootProject.ext.parentGradleProps.version
 }


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.