### PR TITLE
Remove malformed check for already used ports (fixes #147)

### DIFF
--- a/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
+++ b/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
@@ -59,20 +59,6 @@ abstract class LauncherBase implements Launcher {
 
     File portPropertiesFile = getPortPropertiesFile()
     portPropertiesFile.parentFile.mkdirs()
-    if(portPropertiesFile.exists()) {
-      Properties portProps = new Properties()
-      portPropertiesFile.withReader 'UTF-8', {
-        portProps.load(it)
-      }
-      int servicePort = portProps.servicePort as int
-      int statusPort = portProps.statusPort as int
-      ServiceProtocol.createReader(statusPort).withCloseable { reader ->
-        def response = reader.readMessageAsync()
-        ServiceProtocol.createWriter(servicePort).write('status')
-        if (response.get() == 'started')
-          throw new RuntimeException('Web-server is already running.')
-      }
-    }
   }
 
   @Override


### PR DESCRIPTION
Because #138 removed adequate error handling, the check for
already used ports was broken and caused Gretty to fail in
case the 'gretty_ports.properties' file was present.

I think the check is now obsolete because #138 removed the
ability to manually specify fixed service and status ports
for Gretty. As a result, Gretty's ports will never clash
from one Gretty invocation to the next.

If the check was restored, it would only check if the
previous Gretty invocation had already terminated.

If one of the *servlet container ports* clashed, I deem
the current behavior (BindException) sufficient.

---
tl;dr: I tried to wrap my head around the question why would anybody check the ports of the prior execution and could not find a good answer. Maybe the check made sense when we still could tell Gretty to use fixed service/status ports (which is no longer the case). If you have an idea or any concerns, please share them.