### PR TITLE
Set initial log level (fixes #150)

### DIFF
--- a/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
+++ b/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
@@ -194,6 +194,9 @@ abstract class LauncherBase implements Launcher {
           JavaExecParams params = new JavaExecParams()
           params.main = 'org.akhikhl.gretty.Runner'
           params.args = ["--statusPort=${reader.port}", "--serverManagerFactory=${getServerManagerFactory()}"]
+          if (log.isDebugEnabled()) {
+            params.args += "--debug"
+          }
           params.debug = config.getDebug()
           params.debugSuspend = config.getDebugSuspend()
           params.debugPort = config.getDebugPort()

--- a/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/LogUtil.groovy
+++ b/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/LogUtil.groovy
@@ -1,0 +1,15 @@
+package org.akhikhl.gretty
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import org.slf4j.LoggerFactory
+
+class LogUtil {
+
+    static setLevel(boolean debugEnabled) {
+        def logger = LoggerFactory.getLogger(LogUtil.class.getPackage().getName())
+        if (logger instanceof Logger) {
+            logger.level = debugEnabled ? Level.DEBUG : Level.INFO
+        }
+    }
+}

--- a/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
+++ b/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
@@ -45,15 +45,16 @@ final class Runner {
   static void main(String[] args) {
     def cli = new CliBuilder()
     cli.with {
+      d longOpt: 'debug', type: Boolean, 'enable debug logging'
       st longOpt: 'statusPort', required: true, args: 1, argName: 'statusPort', type: Integer, 'status port'
       smf longOpt: 'serverManagerFactory', required: true, args: 1, argName: 'serverManagerFactory', type: String, 'server manager factory'
     }
     def options = cli.parse(args)
-    Map params = [statusPort: options.statusPort as int, serverManagerFactory: options.serverManagerFactory]
+    Map params = [statusPort: options.statusPort as int, serverManagerFactory: options.serverManagerFactory, debug: options.debug]
     new Runner(params).run()
   }
 
-  static void initLogback(Map serverParams) {
+  void initLogback(Map serverParams) {
     LoggerContext logCtx = LoggerFactory.getILoggerFactory()
     logCtx.stop()
     Map loggerCache = LoggerFactory.getILoggerFactory().@loggerCache
@@ -78,6 +79,7 @@ final class Runner {
     binding.fileLogEnabled = Boolean.valueOf(serverParams.fileLogEnabled == null ? true : serverParams.fileLogEnabled)
     binding.logFileName = serverParams.logFileName
     binding.logDir = serverParams.logDir
+    binding.grettyDebug = params.debug
     new GafferConfiguratorEx(logCtx).run(binding, logbackConfigText)
   }
 
@@ -107,7 +109,7 @@ final class Runner {
   }
 
   private void run() {
-
+    LogUtil.setLevel(params.debug)
     boolean paramsLoaded = false
     def ServerManagerFactory = Class.forName(params.serverManagerFactory, true, this.getClass().classLoader)
     ServerManager serverManager = ServerManagerFactory.createServerManager()

--- a/libs/gretty-runner/src/main/resources/grettyRunnerLogback.groovy
+++ b/libs/gretty-runner/src/main/resources/grettyRunnerLogback.groovy
@@ -54,3 +54,5 @@ logger 'org.eclipse.jetty.annotations.AnnotationConfiguration', ERROR
 logger 'org.eclipse.jetty.annotations.AnnotationParser', ERROR
 
 logger 'org.eclipse.jetty.util.component.AbstractLifeCycle', ERROR
+
+logger 'org.akhikhl.gretty', grettyDebug ? DEBUG : INFO


### PR DESCRIPTION
Prior to this patch, Gretty uses Logbacks default log level
of DEBUG until the server start command had been received,
and Gretty reconfigures Logback according to the server
parameters.

This has caused a situation in which log messages prior to
server start are useful (command line arguments, network
setup, commands received other than 'server start'), but
were not properly thresholded.

This patch establishes a log level for all log messages
prior to receiving the server start command. To this end,
the runner accepts a "--debug" command line flag to turn
on debug logging, and sets INFO otherwise.
The Gretty Gradle process invoking the runner turns on the
debug flag only if its process itself was invoked with
"--debug", as in `./gradlew --debug :helloGretty:appRun`.

This type of setup is repeated in the default logging
configuration in `grettyRunnerLogback.groovy`.
If the server start parameters contain a different Logback
configuration file, it takes precedence over the debug
flag.