### PR TITLE
Fix wrong serization of the initParameters in productBuild

### DIFF
--- a/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
+++ b/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
@@ -334,7 +334,7 @@ abstract class LauncherBase implements Launcher {
           if(wconfig.extraResourceBases)
             extraResourceBases wconfig.extraResourceBases.collect({ self.fileToString(it) })
           if(wconfig.initParameters)
-            initParams wconfig.initParameters
+            initParameters wconfig.initParameters
           if(wconfig.realm)
             realm wconfig.realm
           if(wconfig.realmConfigFile)

--- a/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
+++ b/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
@@ -103,7 +103,7 @@ class JettyServerConfigurer {
     if (context.respondsTo('setPersistTempDirectory')) // not supported on older jetty versions
       context.setPersistTempDirectory(true)
 
-    webapp.initParams?.each { key, value ->
+    webapp.initParameters?.each { key, value ->
       context.setInitParameter(key, value)
     }
 

--- a/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
+++ b/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
@@ -246,7 +246,7 @@ class TomcatServerConfigurer {
     loader.setDelegate(true)
     context.setLoader(loader)
 
-    webapp.initParams?.each { key, value ->
+    webapp.initParameters?.each { key, value ->
       context.addParameter(key, value)
     }
 

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProductConfigurer.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProductConfigurer.groovy
@@ -513,7 +513,7 @@ Version: ${project.version}"""
           if(wconfig.extraResourceBases)
             extraResourceBases wconfig.extraResourceBases.collect { 'extraResources/' + webappDestName + '/' + getFileName(it) }
           if(wconfig.initParameters)
-            initParams wconfig.initParameters
+            initParameters wconfig.initParameters
           if(wconfig.realm)
             realm wconfig.realm
           if(wconfig.realmConfigFile)


### PR DESCRIPTION
initParameters were wrongly serialized as initParams into server.json config file on producBuild task.

`integrationTests/testInitParameter` test can be used for verification, without the fix result of the `productBuild` task is not runnable.