### PR TITLE
Limit usage of Tomcat's Connector#setProperty to a minimum

### DIFF
--- a/integrationTests/helloGretty/build.gradle
+++ b/integrationTests/helloGretty/build.gradle
@@ -13,6 +13,7 @@ gretty {
   // Possible servletContainer values are 'jetty7', 'jetty8', 'jetty9', 'tomcat85', 'tomcat9'. Default is 'jetty9'.
   // servletContainer = 'tomcat8'
   // httpsEnabled = true
+  httpIdleTimeout = 424242
 }
 
 war {

--- a/integrationTests/helloGrettySecure/build.gradle
+++ b/integrationTests/helloGrettySecure/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 gretty {
   httpEnabled = false
   httpsEnabled = true
+  httpsIdleTimeout = 424242
   // Possible servletContainer values are 'jetty7', 'jetty8', 'jetty9', 'tomcat85', 'tomcat9'. Default is 'jetty9'.
   servletContainer = 'jetty9'
   realm 'auth'

--- a/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
+++ b/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
@@ -189,7 +189,7 @@ class TomcatServerConfigurer {
         sslConfig.truststorePassword = params.sslTrustStorePassword
 
       if(params.httpsIdleTimeout)
-        httpsConn.setProperty('keepAliveTimeout', params.httpsIdleTimeout)
+        httpsConn.setProperty('keepAliveTimeout', params.httpsIdleTimeout.toString())
 
       httpsConn.setProperty('maxPostSize', '0')  // unlimited
 

--- a/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
+++ b/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
@@ -23,6 +23,7 @@ import org.apache.catalina.startup.Catalina
 import org.apache.catalina.startup.Tomcat
 import org.apache.catalina.startup.Tomcat.DefaultWebXmlListener
 import org.apache.catalina.startup.Tomcat.FixContextListener
+import org.apache.tomcat.util.net.SSLHostConfig
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.xml.sax.InputSource
@@ -136,8 +137,12 @@ class TomcatServerConfigurer {
       if(httpsConn.port == PortUtils.RANDOM_FREE_PORT)
         httpsConn.port = 0
 
+      def sslConfig = new SSLHostConfig()
+      httpsConn.addSslHostConfig(sslConfig)
+      def cert = sslConfig.getCertificates(true).first()
+
       if(params.sslKeyManagerPassword)
-        httpsConn.setProperty('keyPass', params.sslKeyManagerPassword)
+        cert.certificateKeyPassword = params.sslKeyManagerPassword
       if(params.sslKeyStorePath) {
         if(params.sslKeyStorePath.startsWith('classpath:')) {
           String resString = params.sslKeyStorePath - 'classpath:'
@@ -153,13 +158,13 @@ class TomcatServerConfigurer {
               outs << stm
             }
           }
-          httpsConn.setProperty('keystoreFile', keystoreFile.absolutePath)
+          cert.certificateKeystoreFile = keystoreFile.absolutePath
         }
         else
-          httpsConn.setProperty('keystoreFile', params.sslKeyStorePath)
+          cert.certificateKeystoreFile = params.sslKeyStorePath
       }
       if(params.sslKeyStorePassword)
-        httpsConn.setProperty('keystorePass', params.sslKeyStorePassword)
+        cert.certificateKeystorePassword = params.sslKeyStorePassword
       if(params.sslTrustStorePath) {
         if(params.sslTrustStorePath.startsWith('classpath:')) {
           String resString = params.sslTrustStorePath - 'classpath:'
@@ -175,13 +180,13 @@ class TomcatServerConfigurer {
               outs << stm
             }
           }
-          httpsConn.setProperty('truststoreFile', truststoreFile.absolutePath)
+          sslConfig.truststoreFile = truststoreFile.absolutePath
         }
         else
-          httpsConn.setProperty('truststoreFile', params.sslTrustStorePath)
+          sslConfig.truststoreFile = params.sslTrustStorePath
       }
       if(params.sslTrustStorePassword)
-        httpsConn.setProperty('truststorePass', params.sslTrustStorePassword)
+        sslConfig.truststorePassword = params.sslTrustStorePassword
 
       if(params.httpsIdleTimeout)
         httpsConn.setProperty('keepAliveTimeout', params.httpsIdleTimeout)

--- a/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
+++ b/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
@@ -109,7 +109,7 @@ class TomcatServerConfigurer {
         httpConn.port = 0
 
       if(params.httpIdleTimeout)
-        httpConn.setProperty('keepAliveTimeout', params.httpIdleTimeout.toString())
+        assert httpConn.setProperty('keepAliveTimeout', params.httpIdleTimeout.toString())
 
       httpConn.maxPostSize = -1 // unlimited post size
 
@@ -127,7 +127,7 @@ class TomcatServerConfigurer {
         httpsConn = new Connector('HTTP/1.1')
         httpsConn.scheme = 'https'
         httpsConn.secure = true
-        httpsConn.setProperty('SSLEnabled', 'true')
+        assert httpsConn.setProperty('SSLEnabled', 'true')
     }
 
     if(httpsConn) {
@@ -189,7 +189,7 @@ class TomcatServerConfigurer {
         sslConfig.truststorePassword = params.sslTrustStorePassword
 
       if(params.httpsIdleTimeout)
-        httpsConn.setProperty('keepAliveTimeout', params.httpsIdleTimeout.toString())
+        assert httpsConn.setProperty('keepAliveTimeout', params.httpsIdleTimeout.toString())
 
       httpsConn.maxPostSize = -1  // unlimited
 

--- a/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
+++ b/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
@@ -111,7 +111,7 @@ class TomcatServerConfigurer {
       if(params.httpIdleTimeout)
         httpConn.setProperty('keepAliveTimeout', params.httpIdleTimeout.toString())
 
-      httpConn.setProperty('maxPostSize', '0') // unlimited post size
+      httpConn.maxPostSize = -1 // unlimited post size
 
       if(newHttpConnector) {
         service.addConnector(httpConn)
@@ -191,7 +191,7 @@ class TomcatServerConfigurer {
       if(params.httpsIdleTimeout)
         httpsConn.setProperty('keepAliveTimeout', params.httpsIdleTimeout.toString())
 
-      httpsConn.setProperty('maxPostSize', '0')  // unlimited
+      httpsConn.maxPostSize = -1  // unlimited
 
       if(newHttpsConnector) {
         service.addConnector(httpsConn)


### PR DESCRIPTION
This PR contains a couple of general fixes / improvements, which I developed while integrating Tomcat 10 (#144 / #159), that are also useful to existing Tomcat servlet containers prior to version ten.

The changes common motive consists of limiting usage of the stringly-typed method `Connector#setProperty(String name, String value)`:

1. For the SSL commit, this means explicitly creating a `SSLHostConfig`. This gets rid of properties which are already deprecated in Tomcat 9, and cease to exist in Tomcat 10.
2. For `httpsIdleTimeout`, the caller failed to match the signature of `setProperty`, because the second argument was of type Integer, causing a runtime error that prevented using that feature.
3. For `maxPostSize`, that call of `setProperty` never worked, because the target object has no property with that name. Also, the config value of '0' is wrong for the stated purpose. According to Tomcat 8/8.5/9/10 documentation, a value _below_ zero configures unlimited post size.
4. For all remaining properties,  calls to `setProperty` should never fail silently. We should assert on the return value of `setProperty`, which is a bool indicating whether that call succeeded (that the caller has met requirements for property name and data type).