### PR TITLE
Delete deprecated method in jetty 9.4

### DIFF
--- a/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -78,7 +78,6 @@ class JettyConfigurerImpl implements JettyConfigurer {
     if(params.httpEnabled && !httpConn) {
       newHttpConnector = true
       httpConn = new ServerConnector(server, new HttpConnectionFactory(http_config))
-      httpConn.soLingerTime = -1
     }
 
     if(httpConn) {
@@ -108,7 +107,6 @@ class JettyConfigurerImpl implements JettyConfigurer {
       httpsConn = new ServerConnector(server,
         new SslConnectionFactory(new SslContextFactory(), 'http/1.1'),
         new HttpConnectionFactory(https_config))
-      httpsConn.soLingerTime = -1
     }
 
     if(httpsConn) {


### PR DESCRIPTION
- Reference : [Issue #2468 - Remove SoLinger.](https://github.com/eclipse/jetty.project/pull/2644)

- Hello, I using jetty version 9.4 in gretty. when i started to server with command(`./gradlew jettyRunWar`), the message below being printed out.

- The message is because the `soLingerTime` has been deprecated in Jetty 9.4 version.

```
WARN Ignoring deprecated socket close linger time
```

- I'm not sure if this MR is correct way 😄 Thank you for providing a good plug-in.


