### PR TITLE
Non-blocking farm initialization. Fix context cleanup on "redeploy".

### DIFF
--- a/integrationTests/farm/MyWebApp/build.gradle
+++ b/integrationTests/farm/MyWebApp/build.gradle
@@ -6,11 +6,14 @@ apply plugin: 'org.gretty.internal.integrationTests.FarmIntegrationTestPlugin'
 dependencies {
   compile 'org.webjars:bootstrap:3.2.0'
   compile 'org.webjars:jquery:2.1.1'
+  compile 'org.apache.httpcomponents:httpclient:4.2.1'
 }
 
 farm {
-  webapp project
+  redeployMode = "redeploy"
+
   webapp ':farm:MyWebService'
+  webapp project
 }
 
 // adds additional file to the product build, for testing purpose
@@ -21,6 +24,6 @@ product {
 defineIntegrationTest()
 
 testAll.dependsOn defineFarmIntegrationTestAllContainers({
-  webapp project
   webapp ':farm:MyWebService'
+  webapp project
 })

--- a/integrationTests/farm/MyWebApp/src/main/java/org/akhikhl/examples/gretty/MyWebAppContextListener.java
+++ b/integrationTests/farm/MyWebApp/src/main/java/org/akhikhl/examples/gretty/MyWebAppContextListener.java
@@ -1,0 +1,36 @@
+package org.akhikhl.examples.gretty;
+
+import java.io.IOException;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+
+public class MyWebAppContextListener implements ServletContextListener {
+  @Override
+  public void contextInitialized(ServletContextEvent sce) {
+    HttpClient client = new DefaultHttpClient();
+    HttpPost request = new HttpPost("http://localhost:8080/MyWebService/getdate");
+    HttpResponse response;
+
+    try {
+      response = client.execute(request);
+      if (response.getStatusLine().getStatusCode() != 200) {
+        throw new RuntimeException("Web service in farm test is not yet available!");
+      }
+      EntityUtils.consume(response.getEntity());
+    } catch (IOException e) {
+      throw new RuntimeException("Web service in farm test is not yet available!");
+    } finally {
+      client.getConnectionManager().shutdown();
+    }
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent sce) {}
+}

--- a/integrationTests/farm/MyWebApp/src/main/webapp/WEB-INF/web.xml
+++ b/integrationTests/farm/MyWebApp/src/main/webapp/WEB-INF/web.xml
@@ -3,6 +3,10 @@
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
 
+  <listener>
+    <listener-class>org.akhikhl.examples.gretty.MyWebAppContextListener</listener-class>
+  </listener>
+
   <filter>
     <filter-name>RedirectFilter</filter-name>
     <filter-class>org.akhikhl.gretty.RedirectFilter</filter-class>

--- a/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
+++ b/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
@@ -62,22 +62,11 @@ class JettyServerConfigurer {
 
     def server = configurer.createServer()
 
-    File baseDir = new File(params.baseDir)
-    new File(baseDir, 'webapps').mkdirs()
+    new File(params.baseDir, 'webapps').mkdirs()
 
     configurer.applyJettyXml(server, params.serverConfigFile)
-
     configurer.configureConnectors(server, params)
-
-    List handlers = []
-
-    for(Map webapp in params.webApps) {
-      def context = createContext(webapp, baseDir, server, configureContext)
-      handlers.add(context)
-    }
-
-    configurer.setHandlersToServer(server, handlers)
-
+    configurer.setHandlersToServer(server, [])
     return server
   }
 

--- a/libs/gretty-runner-jetty7/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty7/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -310,5 +310,7 @@ class JettyConfigurerImpl implements JettyConfigurer {
   void addHandlerToServer(server, handler) {
     ContextHandlerCollection collection = findContextHandlerCollection(server.handler)
     collection.addHandler(handler)
+    collection.manage(handler)
+    handler.start()
   }
 }

--- a/libs/gretty-runner-jetty8/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty8/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -323,5 +323,7 @@ class JettyConfigurerImpl implements JettyConfigurer {
   void addHandlerToServer(server, handler) {
     def collection = findContextHandlerCollection(server.handler)
     collection.addHandler(handler)
+    collection.manage(handler)
+    handler.start()
   }
 }

--- a/libs/gretty-runner-jetty9/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty9/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -316,6 +316,8 @@ class JettyConfigurerImpl implements JettyConfigurer {
   void addHandlerToServer(server, handler) {
     def collection = findContextHandlerCollection(server.handler)
     collection.addHandler(handler)
+    collection.manage(handler)
+    handler.start()
   }
 
 }

--- a/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -315,6 +315,8 @@ class JettyConfigurerImpl implements JettyConfigurer {
   void addHandlerToServer(server, handler) {
     def collection = findContextHandlerCollection(server.handler)
     collection.addHandler(handler)
+    collection.manage(handler)
+    handler.start()
   }
 
 }

--- a/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -308,6 +308,14 @@ class JettyConfigurerImpl implements JettyConfigurer {
   void addHandlerToServer(server, handler) {
     def collection = findContextHandlerCollection(server.handler)
     collection.addHandler(handler)
+
+    // we need to make new handler managed by the HandlerCollection 
+    // so it is stopped automatically when the whole server is stopped
+    // or when handler is removed from collection.
+    collection.manage(handler)
+
+    // addHandler and manage don't start the context, so we need to do start it manually
+    handler.start()
   }
 
 }

--- a/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
+++ b/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
@@ -212,11 +212,6 @@ class TomcatServerConfigurer {
     if(params.singleSignOn && !tomcat.host.pipeline.valves.find { it instanceof SingleSignOn })
       tomcat.host.addValve(new SingleSignOn())
 
-    for(Map webapp in params.webApps) {
-      StandardContext context = createContext(webapp, tomcat, configureContext)
-      tomcat.host.addChild(context)
-    }
-
     tomcat
   }
 


### PR DESCRIPTION
This change makes sure that apps are started and become available in the order in which they are defined in the farm config.
Order was kind of already guaranted because gretty is using `[:]` for webapps list (which is LinkedHashMap), but server was available only when all webapps were initialized. So it was not possible to have webapps to depend on the availability of other apps.

As a side-effect I've also discovered bug with `redeployMode = "redeploy"` for jetty container. This change fixes it. 
Previously old contexts were properly stopped only on the first redeploy, but all subsequent redeploys didn't actually stop old contexts. Only new contexts were reachable from the web server but old ones were still hanging in the memory.

This change is covered by integration test, see `farm` test. there is new `ServletContextListener` that is issuing HTTP request to the webapp that should be loaded first.