### PR TITLE
Annotate `WebAppConfig` to fix Gradle Deprecation Warnings

### DIFF
--- a/integrationTests/gradle.properties
+++ b/integrationTests/gradle.properties
@@ -1,3 +1,4 @@
 rootProjectName = gretty-integrationTests
 group = org.gretty.internal.integrationTests
+org.gradle.warning.mode=all
 # other properties are copied by gradle script from top-level project

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppAfterIntegrationTestTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppAfterIntegrationTestTask.groovy
@@ -10,6 +10,7 @@ package org.akhikhl.gretty
 
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -39,10 +40,12 @@ class AppAfterIntegrationTestTask extends AppStopTask {
     System.out.println 'Server stopped.'
   }
 
+  @Internal
   String getIntegrationTestTask() {
     integrationTestTask_ ?: project.gretty.integrationTestTask
   }
 
+  @Internal
   boolean getIntegrationTestTaskAssigned() {
     integrationTestTaskAssigned
   }

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppBeforeIntegrationTestTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppBeforeIntegrationTestTask.groovy
@@ -10,6 +10,7 @@ package org.akhikhl.gretty
 
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
+import org.gradle.api.tasks.Internal
 import org.gradle.process.JavaForkOptions
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -39,10 +40,12 @@ class AppBeforeIntegrationTestTask extends AppStartTask {
     true
   }
 
+  @Internal
   String getIntegrationTestTask() {
     integrationTestTask_ ?: project.gretty.integrationTestTask
   }
 
+  @Internal
   boolean getIntegrationTestTaskAssigned() {
     integrationTestTaskAssigned
   }

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppServiceTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppServiceTask.groovy
@@ -12,6 +12,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -47,5 +48,6 @@ abstract class AppServiceTask extends DefaultTask {
     ServiceProtocol.createWriter(servicePort).write(command)
   }
 
+  @Internal
   abstract String getCommand()
 }

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppStartTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppStartTask.groovy
@@ -18,7 +18,7 @@ import org.gradle.api.tasks.Internal
  * @author akhikhl
  */
 @CompileStatic(TypeCheckingMode.SKIP)
-class AppStartTask extends StartBaseTask implements ServerConfigWithInputs, WebAppConfigWithInputs {
+class AppStartTask extends StartBaseTask implements TaskWithServerConfig, TaskWithWebAppConfig {
 
   @Delegate
   private ServerConfig serverConfig = new ServerConfig()

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppStartTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/AppStartTask.groovy
@@ -10,6 +10,7 @@ package org.akhikhl.gretty
 
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
+import org.gradle.api.tasks.Internal
 
 /**
  * Gradle task for starting jetty
@@ -17,7 +18,7 @@ import groovy.transform.TypeCheckingMode
  * @author akhikhl
  */
 @CompileStatic(TypeCheckingMode.SKIP)
-class AppStartTask extends StartBaseTask implements ServerConfigWithInputs {
+class AppStartTask extends StartBaseTask implements ServerConfigWithInputs, WebAppConfigWithInputs {
 
   @Delegate
   private ServerConfig serverConfig = new ServerConfig()
@@ -29,6 +30,7 @@ class AppStartTask extends StartBaseTask implements ServerConfigWithInputs {
     servletContainer
   }
 
+  @Internal
   protected boolean getEffectiveInplace() {
     if(webAppConfig.inplace != null)
       webAppConfig.inplace
@@ -38,6 +40,7 @@ class AppStartTask extends StartBaseTask implements ServerConfigWithInputs {
       true
   }
 
+  @Internal
   protected String getEffectiveInplaceMode() {
     if(webAppConfig.inplaceMode != null)
       webAppConfig.inplaceMode

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/FarmStartTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/FarmStartTask.groovy
@@ -14,7 +14,7 @@ import org.gradle.api.Project
  *
  * @author akhikhl
  */
-class FarmStartTask extends StartBaseTask implements ServerConfigWithInputs {
+class FarmStartTask extends StartBaseTask implements TaskWithServerConfig {
 
   String farmName = ''
 

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
@@ -15,6 +15,9 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.JavaForkOptions
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
@@ -28,9 +31,13 @@ import org.springframework.boot.devtools.livereload.LiveReloadServer
 @CompileStatic(TypeCheckingMode.SKIP)
 abstract class StartBaseTask extends DefaultTask {
 
+  @Internal
   boolean interactive = true
+  @Internal
   boolean debug = false
+  @Internal
   Integer debugPort
+  @Internal
   Boolean debugSuspend
 
   private JacocoHelper jacocoHelper
@@ -38,6 +45,7 @@ abstract class StartBaseTask extends DefaultTask {
   protected final List<Closure> prepareServerConfigClosures = []
   protected final List<Closure> prepareWebAppConfigClosures = []
 
+  @Internal
   Map serverStartInfo
 
   StartBaseTask() {
@@ -130,14 +138,17 @@ abstract class StartBaseTask extends DefaultTask {
     }
   }
 
+  @Internal
   protected boolean getDefaultJacocoEnabled() {
     false
   }
 
+  @Internal
   protected boolean getIntegrationTest() {
     false
   }
 
+  @Internal
   JacocoTaskExtension getJacoco() {
     jacocoHelper?.jacoco
   }
@@ -162,6 +173,7 @@ abstract class StartBaseTask extends DefaultTask {
     }
   }
 
+  @Internal
   protected final LauncherConfig getLauncherConfig() {
 
     def self = this
@@ -244,18 +256,22 @@ abstract class StartBaseTask extends DefaultTask {
     sconfig.managedClassReload
   }
 
+  @Internal
   Collection<URL> getRunnerClassPath() {
     DefaultLauncher.getRunnerClassPath(project, getStartConfig().serverConfig)
   }
 
+  @Internal
   protected abstract StartConfig getStartConfig()
 
+  @Internal
   protected abstract String getStopCommand()
 
   /**
    * key is context path, value is collection of classpath URLs
    * @return
    */
+  @Internal
   Map<String, Collection<URL> > getWebappClassPaths() {
     LauncherConfig config = getLauncherConfig()
     WebAppClassPathResolver resolver = config.getWebAppClassPathResolver()

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/TaskWithServerConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/TaskWithServerConfig.groovy
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
-interface ServerConfigWithInputs {
+interface TaskWithServerConfig {
     @Optional
     @Input
     List<String> getJvmArgs()

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/TaskWithWebAppConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/TaskWithWebAppConfig.groovy
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
-interface WebAppConfigWithInputs {
+interface TaskWithWebAppConfig {
 
     @Input
     @Optional

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/WebAppConfigWithInputs.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/WebAppConfigWithInputs.groovy
@@ -1,0 +1,105 @@
+package org.akhikhl.gretty
+
+import org.gradle.api.model.ReplacedBy
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+
+interface WebAppConfigWithInputs {
+
+    @Input
+    @Optional
+    Object getContextPath()
+
+    @Input
+    @Optional
+    Object getInitParameters()
+
+    @Internal
+    Object getRealm()
+
+    @Internal
+    Object getRealmConfigFile()
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    @Optional
+    Object getContextConfigFile()
+
+    @ReplacedBy("contextConfigFile")
+    Object getJettyEnvXmlFile()
+
+    @Internal
+    Object getScanDirs()
+
+    @Input
+    @Optional
+    Boolean getScanDependencies()
+
+    @Input
+    @Optional
+    Object getFastReload()
+
+    @Input
+    @Optional
+    Boolean getRecompileOnSourceChange()
+
+    @Input
+    @Optional
+    Boolean getReloadOnClassChange()
+
+    @Input
+    @Optional
+    Boolean getReloadOnConfigChange()
+
+    @Input
+    @Optional
+    Boolean getReloadOnLibChange()
+
+    @Input
+    @Optional
+    Object getResourceBase()
+
+    @Input
+    @Optional
+    List getExtraResourceBases()
+
+    @Input
+    @Optional
+    Set<String> getBeforeClassPath()
+
+    @Input
+    @Optional
+    Set<String> getClassPath()
+
+    @Input
+    @Optional
+    String getWebInfIncludeJarPattern()
+
+    @Input
+    @Optional
+    String getProjectPath()
+
+    @Input
+    @Optional
+    Boolean getInplace()
+
+    @Input
+    @Optional
+    String getInplaceMode()
+
+    @Input
+    @Optional
+    String getWebXml()
+
+    @Input
+    @Optional
+    Boolean getSpringBoot()
+
+    @Input
+    @Optional
+    String getSpringBootMainClass()
+}


### PR DESCRIPTION
I did some reading & analysis and this fixes a couple of warnings from #133. I'm very unsure about this solution, please see for yourself and decide if we need to rethink. I dislike:

- the amount of boilerplate added: if it weren't for the `@Delegate`, we could just annotate the Groovy property as in:  
  ```groovy
  class WebAppConfig {
    @Input
    @Optional
    def contextPath
    // ...
  }
  ```
- making "gretty-core" dependent on Gradle's API, polluting those data transfer objects with Gradle-specific input and output logic.

@boris-petrov I made this a draft PR - please tell me what you think and then we figure out how to proceed.