### PR TITLE
Use java gradle plugin

### DIFF
--- a/libs/gretty/build.gradle
+++ b/libs/gretty/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java-gradle-plugin'
-  id 'com.gradle.plugin-publish' version '0.11.0'
+  id 'com.gradle.plugin-publish' version '0.13.0'
 }
 
 apply from: rootProject.file('common.gradle')

--- a/libs/gretty/build.gradle
+++ b/libs/gretty/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+  id 'java-gradle-plugin'
   id 'com.gradle.plugin-publish' version '0.11.0'
 }
 

--- a/libs/gretty/build.gradle
+++ b/libs/gretty/build.gradle
@@ -38,3 +38,7 @@ pluginBundle {
     }
   }
 }
+
+validatePlugins {
+  enableStricterValidation = true
+}

--- a/libs/gretty/build.gradle
+++ b/libs/gretty/build.gradle
@@ -16,6 +16,15 @@ dependencies {
   implementation gradleApi()
 }
 
+gradlePlugin {
+  plugins {
+    grettyPlugin {
+      id = 'org.gretty'
+      implementationClass = 'org.akhikhl.gretty.GrettyPlugin'
+    }
+  }
+}
+
 pluginBundle {
   website = 'https://gretty-gradle-plugin.github.io/gretty-doc/'
   vcsUrl = "https://github.com/${developerId}/gretty"

--- a/libs/gretty/src/main/resources/META-INF/gradle-plugins/org.gretty.properties
+++ b/libs/gretty/src/main/resources/META-INF/gradle-plugins/org.gretty.properties
@@ -1,1 +1,0 @@
-implementation-class=org.akhikhl.gretty.GrettyPlugin


### PR DESCRIPTION
This adds validation for the task classes which is run on check.

It also currently adds a Maven publication called `PluginMavenPublication` to the `gretty` subproject. The `PluginMaven` publishes the same things as the `MavenJava` publication, so if you publish both things they will override each other. I checked the publication code, and it seem like only one publication is published when publishing, so I think we are good. Is there any way to try this out?