### PR TITLE
Remove maven plugin for publishing

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation 'org.apache.commons:commons-lang3:3.4'
-    implementation 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+    implementation 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     implementation 'org.jfrog.buildinfo:build-info-extractor-gradle:4.11.0'
     implementation "org._10ne.gradle:rest-gradle-plugin:0.4.2"
     implementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'

--- a/buildSrc/src/main/groovy/grettybuild.common.gradle
+++ b/buildSrc/src/main/groovy/grettybuild.common.gradle
@@ -58,8 +58,6 @@ ext.configurePublications = { String publicationName ->
                     }
                 }
             }
-            artifact tasks.sourcesJar
-            artifact tasks.javadocJar
         }
     }
 
@@ -109,15 +107,12 @@ ext.configurePublications = { String publicationName ->
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
-task sourcesJar(type: Jar, dependsOn: classes, description: 'Creates sources jar') {
-    archiveClassifier = 'sources'
-    from sourceSets.main.allSource
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
-task javadocJar(type: Jar, description: 'Creates javadoc jar') {
-    dependsOn javadoc
-    archiveClassifier = 'javadoc'
-    from javadoc.destinationDir
+tasks.named("javadocJar", Jar).configure {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     def groovydocTask = tasks.groovydoc
     dependsOn groovydocTask

--- a/buildSrc/src/main/groovy/grettybuild.common.gradle
+++ b/buildSrc/src/main/groovy/grettybuild.common.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java-library'
     id 'groovy'
-    id 'maven'
     id 'maven-publish'
     id 'com.jfrog.artifactory'
     id 'com.jfrog.bintray'
@@ -31,39 +30,33 @@ ext.configurePublications = { String publicationName ->
 
     def thisProject = project
 
-    // When the maven plugin has been removed, this should be converted to using the API on MavenPublication.pom
-    def configurePom = {
-        resolveStrategy = Closure.DELEGATE_FIRST
-        packaging 'jar'
-        description thisProject.description
-        url thisProject.project_website
-
-        scm {
-            url thisProject.project_scm
-            connection thisProject.project_scm
-            developerConnection thisProject.project_scm
-        }
-
-        licenses {
-            license {
-                name thisProject.license
-                url thisProject.license_url
-                distribution 'repo'
-            }
-        }
-
-        developers {
-            developer {
-                id thisProject.developerId
-                name thisProject.developerName
-            }
-        }
-    }
-
     publishing {
         publications.named(publicationName, MavenPublication) {
-            pom.withXml {
-                asNode().children().last() + configurePom
+            pom {
+                packaging = 'jar'
+                description = thisProject.description
+                url = thisProject.project_website
+
+                scm {
+                    url = thisProject.project_scm
+                    connection = thisProject.project_scm
+                    developerConnection = thisProject.project_scm
+                }
+
+                licenses {
+                    license {
+                        name = thisProject.license
+                        url = thisProject.license_url
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = thisProject.developerId
+                        name = thisProject.developerName
+                    }
+                }
             }
             artifact tasks.sourcesJar
             artifact tasks.javadocJar
@@ -79,13 +72,6 @@ ext.configurePublications = { String publicationName ->
     tasks.artifactoryPublish {
         dependsOn { project.tasks."generatePomFileFor${capitalizedPublicationName}Publication" }
         publications publicationName
-    }
-
-    install.repositories.mavenInstaller.pom*.whenConfigured { pom ->
-        pom.project {
-            name thisProject.name
-            configurePom.rehydrate(delegate, owner, thisObject).call()
-        }
     }
 
     bintray {
@@ -136,10 +122,6 @@ task javadocJar(type: Jar, description: 'Creates javadoc jar') {
     def groovydocTask = tasks.groovydoc
     dependsOn groovydocTask
     from groovydocTask.destinationDir
-}
-
-artifacts {
-    archives sourcesJar, javadocJar
 }
 
 afterEvaluate {

--- a/buildSrc/src/main/groovy/grettybuild.common.gradle
+++ b/buildSrc/src/main/groovy/grettybuild.common.gradle
@@ -87,6 +87,37 @@ ext.configurePublications = { String publicationName ->
             configurePom.rehydrate(delegate, owner, thisObject).call()
         }
     }
+
+    bintray {
+        user = project.bintrayUser
+        key = project.bintrayKey
+        publications = [publicationName]
+        pkg {
+            repo = thisProject.bintrayRepo
+            userOrg = thisProject.bintrayUserOrg
+            name = thisProject.bintrayPackage
+            desc = thisProject.description
+            licenses = [ thisProject.license ]
+            vcsUrl = thisProject.project_scm
+            labels = thisProject.projectLabels.split(',')
+            version {
+                name = thisProject.version
+                vcsTag = thisProject.version
+                gpg {
+                    sign = true
+                    passphrase = thisProject.gpgPassphrase
+                }
+            }
+        }
+        dryRun = thisProject.bintrayDryRun
+    }
+
+    tasks.bintrayUpload.dependsOn assemble
+
+    if (!bintrayDryRun && gpgPassphrase) {
+        tasks.bintrayUpload.finalizedBy rootProject.tasks.bintraySign
+        rootProject.tasks.bintraySign.onlyIf { !tasks.bintrayUpload.getState().getFailure() }
+    }
 }
 
 sourceCompatibility = JavaVersion.VERSION_11
@@ -125,38 +156,4 @@ afterEvaluate {
             }
         }
     }
-
-    def thisProject = project
-
-    bintray {
-        user = project.bintrayUser
-        key = project.bintrayKey
-        configurations = ['archives']
-        pkg {
-            repo = thisProject.bintrayRepo
-            userOrg = thisProject.bintrayUserOrg
-            name = thisProject.bintrayPackage
-            desc = thisProject.description
-            licenses = [ thisProject.license ]
-            vcsUrl = thisProject.project_scm
-            labels = thisProject.projectLabels.split(',')
-            version {
-                name = thisProject.version
-                vcsTag = thisProject.version
-                gpg {
-                    sign = true
-                    passphrase = thisProject.gpgPassphrase
-                }
-            }
-        }
-        dryRun = thisProject.bintrayDryRun
-    }
-
-    tasks.bintrayUpload.dependsOn assemble
-
-    if (!bintrayDryRun && gpgPassphrase) {
-        tasks.bintrayUpload.finalizedBy rootProject.tasks.bintraySign
-        rootProject.tasks.bintraySign.onlyIf { !tasks.bintrayUpload.getState().getFailure() }
-    }
-
 } // afterEvaluate


### PR DESCRIPTION
This PR builds on top of https://github.com/gretty-gradle-plugin/gretty/pull/200 and removes the maven plugin from the build, so only the new publishing mechanism is in use.