### PR TITLE
Spring support: avoid classloading of webapp classes before webapp start

### DIFF
--- a/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
+++ b/libs/gretty-runner-jetty/src/main/groovy/org/akhikhl/gretty/JettyServerConfigurer.groovy
@@ -111,8 +111,7 @@ class JettyServerConfigurer {
     }
 
     if (webapp.springBoot) {
-      Class AppServletInitializer = Class.forName('org.akhikhl.gretty.AppServletInitializer', true, context.classLoader)
-      AppServletInitializer.setSpringBootMainClass(webapp.springBootMainClass)
+      context.setInitParameter("GRETTY_SPRING_BOOT_MAIN_CLASS", webapp.springBootMainClass)
     }
     context
   }

--- a/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
+++ b/libs/gretty-runner-tomcat/src/main/groovy/org/akhikhl/gretty/TomcatServerConfigurer.groovy
@@ -233,8 +233,7 @@ class TomcatServerConfigurer {
     URL[] classpathUrls = (webapp.webappClassPath ?: []).collect { new URL(it) } as URL[]
     URLClassLoader classLoader = new URLClassLoader(classpathUrls, parentClassLoader)
     if (webapp.springBoot) {
-      Class AppServletInitializer = Class.forName('org.akhikhl.gretty.AppServletInitializer', true, classLoader)
-      AppServletInitializer.setSpringBootMainClass(webapp.springBootMainClass)
+      context.addParameter('GRETTY_SPRING_BOOT_MAIN_CLASS', webapp.springBootMainClass)
     }
     context.addLifecycleListener(new SpringloadedCleanup())
     context.setParentClassLoader(classLoader)

--- a/libs/gretty-springboot/src/main/groovy/org/akhikhl/gretty/AppServletInitializer.java
+++ b/libs/gretty-springboot/src/main/groovy/org/akhikhl/gretty/AppServletInitializer.java
@@ -1,14 +1,20 @@
 package org.akhikhl.gretty;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 public class AppServletInitializer extends SpringBootServletInitializer {
 
-  public static String springBootMainClass;
+  private String springBootMainClass;
 
-  public static void setSpringBootMainClass(String newValue) {
-    springBootMainClass = newValue;
+  @Override
+  public void onStartup(ServletContext servletContext) throws ServletException {
+    springBootMainClass = requireNonNull(servletContext.getInitParameter("GRETTY_SPRING_BOOT_MAIN_CLASS"));
+    super.onStartup(servletContext);
   }
 
   @Override


### PR DESCRIPTION
This one's a bit harder to explain. This is the only commit that is in my prototypical Jetty 10 branch, but not in master. It's a fix for crash resulting in the combination of classloader rework of Jetty 10 onwards, and the way how Spring integration has been done in Gretty.

- This means for master it's an existing solution for a problem yet-to-come, namely the day we can re-enable Spring integration. Classloading has been reworked in both Jetty 10 and 11, in a way that defers the creation of the classloader to the point where the webapp starts. Trying to load a class before the webapp starts will crash. This is a fix to a dormant fault already in Gretty, just not active because we do not have Spring integration ready as of today. You may notice that it still uses 'javax.'-APIs. This is due to the fact that the module 'gretty-springboot' is still on 'javax'. Leaving it at that means we can use the commit as-is in 3.x.
- For 3.x this offers a stability improvement. I think it's hacky to reach for the classloader of the webapp-to-be-started at configuration time and start loading classes, namely `AppServletInitializer`. I would want Gretty to pass the name of the class as init parameter to the webapp, rather than trying to shoehorn the name into a static field. I view it as easier to understand, and the new way does depend less on classloading.

