### PR TITLE
Improve the dependency resolving logic

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -10,7 +10,6 @@ package org.akhikhl.gretty
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.apache.commons.io.FilenameUtils
-import org.apache.tools.ant.taskdefs.Java
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.slf4j.Logger


### PR DESCRIPTION
I encountered some errors when using this plugin:

1. The transitive dependencies from the sub-module are not excluded even though I added `implementation.exclude module: 'xxx'` in the `configurations` block.
2. The final dependencies contain the duplicated modules with different versions if two modules depend on two different versions.

Then I did some investigation and found that the logic of resolving the project dependencies look problematic. That is, for a multi-module project, it will iterate all the modules and get the dependencies separately, then put them together to produce the final dependencies. But in fact, the final dependencies of a multi-module project are not equal to the sum of its sub-modules' dependencies in most cases. That could explain the problems I encountered.

I suppose that the Gradle API should provide such an API to get the final dependencies of a project, no matter whether it is a multi-module project or not. Then I did some research and found that the Gradle API does provide [a method](https://docs.gradle.org/5.6.4/javadoc/org/gradle/api/artifacts/Configuration.html#resolve--) to retrieve the project's dependencies directly without the need of iterating each sub-project. So I tried to migrate the dependency resolving logic and it worked as expected.

For now, I tested on my project, it's a giant project with multiple modules and it works well. BTW, it also fixes #146 #119