### PR TITLE
Fix Invalid plugin ID 'org.gretty' when running publishPlugins

### DIFF
--- a/libs/gretty/build.gradle
+++ b/libs/gretty/build.gradle
@@ -29,8 +29,7 @@ pluginBundle {
   description = 'Advanced gradle plugin for running web-apps on jetty and tomcat.'
 
   plugins {
-    gretty {
-      id = 'org.gretty'
+    grettyPlugin {
       displayName = 'Gretty plugin'
       tags = [ 'gretty', 'jetty', 'tomcat', 'gradle', 'plugin', 'spring', 'spring-boot' ]
     }


### PR DESCRIPTION
Fixed #208 .