### PR TITLE
Use the `springBoot` option when it is not null

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -246,6 +246,7 @@ final class ProjectUtils {
     new File(getWebAppDir(project), 'WEB-INF')
   }
 
+  // ATTENTION: this function resolves compile configuration!
   static boolean isSpringBootApp(Project project, WebAppConfig wconfig) {
     if(wconfig.springBoot != null) {
       return wconfig.springBoot

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -246,17 +246,17 @@ final class ProjectUtils {
     new File(getWebAppDir(project), 'WEB-INF')
   }
 
-  // ATTENTION: this function resolves compile configuration!
-  static boolean isSpringBootApp(Project project) {
-    def compileConfig = project.configurations.findByName('compileClasspath')
-    compileConfig && compileConfig.resolvedConfiguration.resolvedArtifacts.find { it.moduleVersion.id.group == 'org.springframework.boot' }
-  }
-
   static boolean isSpringBootApp(Project project, WebAppConfig wconfig) {
     if(wconfig.springBoot != null) {
       return wconfig.springBoot
     }
-    wconfig.projectPath && isSpringBootApp(project.project(wconfig.projectPath))
+    if(!wconfig.projectPath) {
+      return false;
+    }
+    def compileConfig = project.project(wconfig.projectPath).configurations.findByName('compileClasspath')
+    compileConfig && compileConfig.resolvedConfiguration.resolvedArtifacts.find {
+      it.moduleVersion.id.group == 'org.springframework.boot'
+    }
   }
 
   static void prepareExplodedWebAppFolder(Project project) {

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -253,7 +253,10 @@ final class ProjectUtils {
   }
 
   static boolean isSpringBootApp(Project project, WebAppConfig wconfig) {
-    wconfig.springBoot || (wconfig.projectPath && isSpringBootApp(project.project(wconfig.projectPath)))
+    if(wconfig.springBoot != null) {
+      return wconfig.springBoot
+    }
+    wconfig.projectPath && isSpringBootApp(project.project(wconfig.projectPath))
   }
 
   static void prepareExplodedWebAppFolder(Project project) {

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
@@ -223,7 +223,7 @@ abstract class StartBaseTask extends DefaultTask {
             Set<URL> resolvedClassPath = new LinkedHashSet<URL>()
             if(wconfig.projectPath) {
               def proj = self.project.project(wconfig.projectPath)
-              String runtimeConfig = ProjectUtils.isSpringBootApp(proj) ? 'springBoot' : 'runtimeClasspath'
+              String runtimeConfig = ProjectUtils.isSpringBootApp(proj, wconfig) ? 'springBoot' : 'runtimeClasspath'
               resolvedClassPath.addAll(ProjectUtils.resolveClassPath(proj, wconfig.beforeClassPath))
               resolvedClassPath.addAll(ProjectUtils.getClassPath(proj, wconfig.inplace, runtimeConfig))
               resolvedClassPath.addAll(ProjectUtils.resolveClassPath(proj, wconfig.classPath))


### PR DESCRIPTION
I'm using the gretty plugin in a complex project, which has the `org.springframework.boot` group id in its `complieClasspath` and that could make gretty treat the project as a spring boot project, but actually it's not a standard spring boot application. So I want to tell gretty that it's not a spring boot project explicity.

I noticed that gretty has an undocumented option named `springBoot` that indicates whether the current project is a spring boot project or not. But we couldn't set it to `false` explicitly to indicates that a project is not a spring boot project. Because inside gretty, it will try to resolve the spring boot dependency when the `springBoot` option is a falsy value. I personally think it doesn't make sense when we the user set it to `false` explicitly.

https://github.com/gretty-gradle-plugin/gretty/blob/85dabc14e44f8250d17e538b369125971e487301/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy#L256

So this PR is to solve the problem above. It will use the `springBoot` option set by the user with higher priority. And fallback to the spring boot detection logic if not set.