### PR TITLE
Add Gradle 7 build job (and support Groovy 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,21 @@ on: ['push', 'pull_request']
 
 jobs:
   build-and-test:
-    name: Java ${{ matrix.java }}
+    name: Gradle ${{ matrix.gradle }} on Java ${{ matrix.java }}
     runs-on: ubuntu-latest
     environment: Bintray
 
     strategy:
       matrix:
         java: [11, 15]
+        gradle: ["6.8.3"]
+        include:
+          - java: 15
+            gradle: "7.0-rc-1"
 
     env:
       TEST_ALL_CONTAINERS: "['tomcat10','jetty11']"
-      GRADLE_VERSION: 6.8.3
+      GRADLE_VERSION: ${{ matrix.gradle }}
       GECKO_DRIVER_VERSION: 0.28.0
       BINTRAY_REPO: maven
       BINTRAY_PACKAGE: org.gretty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         include:
           - java: 15
             gradle: "7.0-rc-1"
+            properties: "-Pspock_version=2.0-M5-groovy-3.0 -PgebVersion=5.0-milestone-1"
 
     env:
       TEST_ALL_CONTAINERS: "['tomcat10','jetty11']"
@@ -22,6 +23,7 @@ jobs:
       GECKO_DRIVER_VERSION: 0.28.0
       BINTRAY_REPO: maven
       BINTRAY_PACKAGE: org.gretty
+      EXTRA_PROPERTIES: ${{ matrix.properties }}
 
     steps:
       - uses: actions/checkout@v2
@@ -43,8 +45,8 @@ jobs:
         run: |
           set -e
           ./gradlew --no-daemon wrapper --gradle-version $GRADLE_VERSION --distribution-type all
-          ./gradlew --no-daemon --warning-mode all build
+          ./gradlew --no-daemon --warning-mode all $EXTRA_PROPERTIES build
           cd integrationTests
-          ../gradlew --no-daemon --warning-mode all -PgeckoDriverPlatform=linux64 -PgeckoDriverVersion=$GECKO_DRIVER_VERSION -PtestAllContainers=$TEST_ALL_CONTAINERS testAll
+          ../gradlew --no-daemon --warning-mode all $EXTRA_PROPERTIES -PgeckoDriverPlatform=linux64 -PgeckoDriverVersion=$GECKO_DRIVER_VERSION -PtestAllContainers=$TEST_ALL_CONTAINERS testAll
           cd ..
           set +e

--- a/build.gradle
+++ b/build.gradle
@@ -130,18 +130,6 @@ artifactory {
 }
 
 ext.libs = [
-  groovy_all: [
-    "org.codehaus.groovy:groovy:$groovy_version",
-    "org.codehaus.groovy:groovy-ant:$groovy_version",
-    "org.codehaus.groovy:groovy-dateutil:$groovy_version",
-    "org.codehaus.groovy:groovy-groovydoc:$groovy_version",
-    "org.codehaus.groovy:groovy-groovysh:$groovy_version",
-    "org.codehaus.groovy:groovy-json:$groovy_version",
-    "org.codehaus.groovy:groovy-nio:$groovy_version",
-    "org.codehaus.groovy:groovy-macro:$groovy_version",
-    "org.codehaus.groovy:groovy-templates:$groovy_version",
-    "org.codehaus.groovy:groovy-xml:$groovy_version",
-  ],
   spock: dependencies.create("org.spockframework:spock-core:$spock_version") {
     exclude module: "groovy-all"
   }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 repositories {
     gradlePluginPortal()
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://dl.bintray.com/content/noamt/gradle-plugins'
     }

--- a/buildSrc/src/main/groovy/grettybuild.common.gradle
+++ b/buildSrc/src/main/groovy/grettybuild.common.gradle
@@ -10,7 +10,7 @@ repositories {
     maven {
         url "file:${project.property("privateRepoDir")}"
     }
-    jcenter()
+    mavenCentral()
 }
 
 group = rootProject.group

--- a/buildSrc/src/main/groovy/grettybuild.common.gradle
+++ b/buildSrc/src/main/groovy/grettybuild.common.gradle
@@ -121,7 +121,6 @@ tasks.named("javadocJar", Jar).configure {
 
 afterEvaluate {
     dependencies {
-        testImplementation libs.groovy_all
         testImplementation libs.spock
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@ jetty11_servlet_api_version = 5.0.0
 tomcat10_version = 10.0.4
 tomcat10_servlet_api_version = 5.0.0
 asm_version = 9.1
-groovy_version = 2.5.14
 spock_version = 1.3-groovy-2.5
 # Updating Logback to 1.2.3 causes a build failure: https://travis-ci.org/github/gretty-gradle-plugin/gretty/jobs/723685603
 logback_version = 1.1.3

--- a/integrationTests/build.gradle
+++ b/integrationTests/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     maven {
       url "file:$privateRepoDir"
     }
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {

--- a/integrationTests/build.gradle
+++ b/integrationTests/build.gradle
@@ -40,16 +40,3 @@ wrapper {
   gradleVersion = '6.8.3'
   distributionType = Wrapper.DistributionType.ALL
 }
-
-ext.libs = [
-  groovy_all: [
-    "org.codehaus.groovy:groovy:${groovy_version}",
-    "org.codehaus.groovy:groovy-dateutil:${groovy_version}",
-    "org.codehaus.groovy:groovy-groovysh:${groovy_version}",
-    "org.codehaus.groovy:groovy-json:${groovy_version}",
-    "org.codehaus.groovy:groovy-nio:${groovy_version}",
-    "org.codehaus.groovy:groovy-macro:${groovy_version}",
-    "org.codehaus.groovy:groovy-templates:${groovy_version}",
-    "org.codehaus.groovy:groovy-xml:${groovy_version}",
-  ]
-]

--- a/integrationTests/buildSrc/build.gradle
+++ b/integrationTests/buildSrc/build.gradle
@@ -42,7 +42,7 @@ subprojects {
       name 'private'
       url "file:/${project.rootProject.ext.privateRepoDir}"
     }
-    jcenter()
+    mavenCentral()
   }
 
   afterEvaluate {

--- a/integrationTests/buildSrc/gretty-integrationTest/build.gradle
+++ b/integrationTests/buildSrc/gretty-integrationTest/build.gradle
@@ -19,7 +19,6 @@ def projectProps = [
   gebVersion: project.gebVersion,
   geckoDriverVersion: project.geckoDriverVersion,
   geckoDriverPlatform: project.geckoDriverPlatform,
-  groovy_version: project.groovy_version,
   seleniumVersion: project.seleniumVersion,
   spock_version: project.spock_version,
   testAllContainers: project.testAllContainers

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
@@ -4,6 +4,8 @@ import org.akhikhl.gretty.ServletContainerConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.testing.Test
+import org.gradle.util.GradleVersion
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -100,6 +102,12 @@ class BasePlugin implements Plugin<Project> {
       project.rootProject.task('wrapper', type: Wrapper) {
         gradleVersion = '6.8.3'
       }
+
+    project.tasks.withType(Test).configureEach {
+      if (GradleVersion.current().baseVersion.version.startsWith("7.")) {
+        useJUnitPlatform()
+      }
+    }
   }
 
   protected void configureTasksAfterEvaluate(Project project) {

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
@@ -76,7 +76,7 @@ class BasePlugin implements Plugin<Project> {
   }
 
   protected void configureRootProjectProperties(Project project) {
-    for(prop in ['gebVersion', 'geckoDriverVersion', 'geckoDriverPlatform', 'groovy_version', 'seleniumVersion', 'spock_version', 'testAllContainers']) {
+    for(prop in ['gebVersion', 'geckoDriverVersion', 'geckoDriverPlatform', 'seleniumVersion', 'spock_version', 'testAllContainers']) {
       if(!project.hasProperty(prop)) {
         project.ext[prop] = ProjectProperties.getString(prop)
       }

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/BasePlugin.groovy
@@ -71,7 +71,7 @@ class BasePlugin implements Plugin<Project> {
         name 'privateRepo'
         url "file:${project.privateRepoDir}"
       }
-      jcenter()
+      mavenCentral()
     }
   }
 

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/groovy/org/akhikhl/gretty/internal/integrationTests/IntegrationTestPlugin.groovy
@@ -3,7 +3,6 @@ package org.akhikhl.gretty.internal.integrationTests
 import org.akhikhl.gretty.AppAfterIntegrationTestTask
 import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 import org.akhikhl.gretty.ServletContainerConfig
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.testing.Test
@@ -30,14 +29,8 @@ class IntegrationTestPlugin extends BasePlugin {
   protected void configureDependencies(Project project) {
     super.configureDependencies(project)
     project.dependencies {
-      integrationTestImplementation "org.codehaus.groovy:groovy:${project.groovy_version}"
-      integrationTestImplementation "org.codehaus.groovy:groovy-dateutil:${project.groovy_version}"
-      integrationTestImplementation "org.codehaus.groovy:groovy-groovysh:${project.groovy_version}"
-      integrationTestImplementation "org.codehaus.groovy:groovy-json:${project.groovy_version}"
-      integrationTestImplementation "org.codehaus.groovy:groovy-nio:${project.groovy_version}"
-      integrationTestImplementation "org.codehaus.groovy:groovy-macro:${project.groovy_version}"
-      integrationTestImplementation "org.codehaus.groovy:groovy-templates:${project.groovy_version}"
-      integrationTestImplementation "org.codehaus.groovy:groovy-xml:${project.groovy_version}"
+      integrationTestImplementation localGroovy()
+      integrationTestImplementation "org.codehaus.groovy:groovy-macro:${GroovySystem.version}"
       integrationTestImplementation project.dependencies.create("org.spockframework:spock-core:${project.spock_version}") {
         exclude module: "groovy-all"
       }

--- a/integrationTests/buildSrc/gretty-integrationTest/src/main/resources/org/akhikhl/gretty/internal/integrationTests/project.properties
+++ b/integrationTests/buildSrc/gretty-integrationTest/src/main/resources/org/akhikhl/gretty/internal/integrationTests/project.properties
@@ -7,7 +7,6 @@ buildOrigin=@buildOrigin@
 gebVersion=@gebVersion@
 geckoDriverVersion=@geckoDriverVersion@
 geckoDriverPlatform=@geckoDriverPlatform@
-groovy_version=@groovy_version@
 seleniumVersion=@seleniumVersion@
 spock_version=@spock_version@
 testAllContainers=@testAllContainers@

--- a/integrationTests/spring-boot-farm-secure/spring-boot-app/build.gradle
+++ b/integrationTests/spring-boot-farm-secure/spring-boot-app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.gretty.internal.integrationTests.IntegrationTestPlugin'
 apply plugin: 'org.gretty.internal.integrationTests.FarmIntegrationTestPlugin'
 
 dependencies {
-  implementation libs.groovy_all
+  implementation localGroovy()
   implementation 'org.webjars:bootstrap:3.2.0'
   implementation 'org.webjars:jquery:2.1.1'
 }

--- a/integrationTests/spring-boot-farm-secure/spring-boot-webservice/build.gradle
+++ b/integrationTests/spring-boot-farm-secure/spring-boot-webservice/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.gretty'
 apply plugin: 'org.gretty.internal.integrationTests.IntegrationTestPlugin'
 
 dependencies {
-  implementation libs.groovy_all
+  implementation localGroovy()
 }
 
 gretty {

--- a/integrationTests/spring-boot-farm/spring-boot-app/build.gradle
+++ b/integrationTests/spring-boot-farm/spring-boot-app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.gretty.internal.integrationTests.IntegrationTestPlugin'
 apply plugin: 'org.gretty.internal.integrationTests.FarmIntegrationTestPlugin'
 
 dependencies {
-  implementation libs.groovy_all
+  implementation localGroovy()
   implementation 'org.webjars:bootstrap:3.2.0'
   implementation 'org.webjars:jquery:2.1.1'
 }

--- a/integrationTests/spring-boot-farm/spring-boot-webservice1/build.gradle
+++ b/integrationTests/spring-boot-farm/spring-boot-webservice1/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.gretty'
 apply plugin: 'org.gretty.internal.integrationTests.IntegrationTestPlugin'
 
 dependencies {
-  implementation libs.groovy_all
+  implementation localGroovy()
 }
 
 gretty {

--- a/integrationTests/spring-boot-farm/spring-boot-webservice2/build.gradle
+++ b/integrationTests/spring-boot-farm/spring-boot-webservice2/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.gretty'
 apply plugin: 'org.gretty.internal.integrationTests.IntegrationTestPlugin'
 
 dependencies {
-  implementation libs.groovy_all
+  implementation localGroovy()
 }
 
 gretty {

--- a/integrationTests/spring-boot-simple/build.gradle
+++ b/integrationTests/spring-boot-simple/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.gretty'
 apply plugin: 'org.gretty.internal.integrationTests.IntegrationTestPlugin'
 
 dependencies {
-  implementation libs.groovy_all
+  implementation localGroovy()
   implementation 'org.webjars:bootstrap:3.2.0'
   implementation 'org.webjars:jquery:2.1.1'
   // We use Velocity for example of template processing within the webapp.

--- a/integrationTests/springBootWebSocket/build.gradle
+++ b/integrationTests/springBootWebSocket/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'org.gretty'
 apply plugin: 'org.gretty.internal.integrationTests.IntegrationTestPlugin'
 
 dependencies {
+  implementation localGroovy()
   implementation 'org.webjars:sockjs-client:0.3.4-1'
   implementation 'org.webjars:stomp-websocket:2.3.3'
 }

--- a/integrationTests/webfragment/build.gradle
+++ b/integrationTests/webfragment/build.gradle
@@ -4,7 +4,7 @@ repositories {
   maven {
     url "file:$privateRepoDir"
   }
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/libs/gretty-common/build.gradle
+++ b/libs/gretty-common/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-	api "org.codehaus.groovy:groovy:$groovy_version"
-	api "org.codehaus.groovy:groovy-ant:$groovy_version"
-	api "org.codehaus.groovy:groovy-groovydoc:$groovy_version"
-	api "org.codehaus.groovy:groovy-templates:$groovy_version"
+	api localGroovy()
 	api "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/libs/gretty-core/build.gradle
+++ b/libs/gretty-core/build.gradle
@@ -5,9 +5,7 @@ plugins {
 import org.apache.tools.ant.filters.*
 
 dependencies {
-  api "org.codehaus.groovy:groovy:$groovy_version"
-  api "org.codehaus.groovy:groovy-json:$groovy_version"
-  api "org.codehaus.groovy:groovy-cli-commons:$groovy_version"
+  api localGroovy()
   api "ch.qos.logback:logback-classic:$logback_version"
   api 'commons-cli:commons-cli:1.3.1'
   api 'commons-configuration:commons-configuration:1.10'

--- a/libs/gretty-filter/build.gradle
+++ b/libs/gretty-filter/build.gradle
@@ -7,11 +7,8 @@ dependencies {
   api 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1', {
     exclude group: 'commons-logging', module: 'commons-logging'
   }
-  api "org.codehaus.groovy:groovy:${groovy_version}"
-  api "org.codehaus.groovy:groovy-servlet:${groovy_version}"
-  api "org.codehaus.groovy:groovy-jmx:${groovy_version}"
-  api "org.codehaus.groovy:groovy-ant:$groovy_version"
-  api "org.codehaus.groovy:groovy-groovydoc:$groovy_version"
-  api "org.codehaus.groovy:groovy-templates:$groovy_version"
+  api localGroovy()
+  api "org.codehaus.groovy:groovy-jmx:${GroovySystem.version}"
+  api "org.codehaus.groovy:groovy-servlet:${GroovySystem.version}"
   api "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/libs/gretty-runner/build.gradle
+++ b/libs/gretty-runner/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 dependencies {
-  api "org.codehaus.groovy:groovy:$groovy_version"
-  api "org.codehaus.groovy:groovy-cli-commons:$groovy_version"
-  api "org.codehaus.groovy:groovy-json:$groovy_version"
+  api localGroovy()
+  api "org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"
+  api "org.codehaus.groovy:groovy-json:${GroovySystem.version}"
   api 'commons-cli:commons-cli:1.3.1'
   api 'commons-io:commons-io:2.4'
   api "ch.qos.logback:logback-classic:$logback_version"

--- a/libs/gretty-spock/build.gradle
+++ b/libs/gretty-spock/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api libs.groovy_all
+  api localGroovy()
   api libs.spock
   api 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 }

--- a/libs/gretty-springboot/build.gradle
+++ b/libs/gretty-springboot/build.gradle
@@ -4,10 +4,7 @@ plugins {
 
 dependencies {
   providedCompile 'javax.servlet:javax.servlet-api:3.0.1'
-  api "org.codehaus.groovy:groovy:$groovy_version"
-  api "org.codehaus.groovy:groovy-ant:$groovy_version"
-  api "org.codehaus.groovy:groovy-groovydoc:$groovy_version"
-  api "org.codehaus.groovy:groovy-templates:$groovy_version"
+  api localGroovy()
   api "org.springframework.boot:spring-boot-starter-web:$springBootVersion", {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
   }

--- a/libs/gretty-starter/build.gradle
+++ b/libs/gretty-starter/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+  api "org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"
   api project(':libs:gretty-core')
 }
 

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
@@ -171,7 +171,6 @@ class GrettyPlugin implements Plugin<Project> {
   private void addRepositories(Project project) {
     project.repositories {
       mavenLocal()
-      jcenter()
       mavenCentral()
       maven { url 'https://repo.spring.io/release' }
       maven { url 'https://repo.spring.io/milestone' }


### PR DESCRIPTION
Due to the recent improvements with regards to Gradle 7, I thought I might add a build job, too. The Gradle upgrade also implies using Groovy 3, which takes me to a major point: I think it is pointless for Gretty to do any effort in actively managing a specific version of Groovy. Instead, Gretty should rely on the Groovy version shipped with Gradle. I mean, Groovy and Gradle versions always co-evolve: I don't think its meaningful to lag behind Gradle's Groovy version, or to anticipate future changes of Gradle to the Groovy version. The added build shows that we can target Groovy 2 and 3 (and therefore Gradle 6.x and 7.x) just fine. This results in the following course of action:

- Adding a Gradle 7.x build job
- Pruning all occurrences of `groovy_version`
- Opting in to the Groovy dependencies which are no longer part of `localGroovy()` in 7.x, see [here](https://docs.gradle.org/7.0-rc-1/userguide/upgrading_version_6.html#groovy_modularization), as Gretty needs it
- Replacing almost all occurrences of `jcenter`, because some updated dependencies already discontinued publishing there

Questions:

1. What about scripts like `pluginScripts/gretty.plugin` ? Will they require updated repositories, too?
2. I don't like hiding dependency updates for Geb and Spock in the GitHub actions file, but for now, I don't know any better. Will we keep building for Gradle 6 and 7 in parallel? Or will we be creating new major releases / branches?
3. When (2) is settled, we might consider using JUnit 5 for both Gradle 6 and 7. There is a separate "vintage" test engine which is able to pick up JUnit 4 tests while running on JUnit 5. That might replace the switch on Gradle 7 in the integration test plugin.

Fixes #193 