### PR TITLE
Explicitly bind to loopback address rather than local address to fix …

### DIFF
--- a/libs/gretty-common/src/main/groovy/org/akhikhl/gretty/ServiceProtocol.groovy
+++ b/libs/gretty-common/src/main/groovy/org/akhikhl/gretty/ServiceProtocol.groovy
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture
 final class ServiceProtocol {
 
   static Reader createReader(int port  = 0) {
-    final ServerSocket serverSocket = new ServerSocket(port, 1, InetAddress.localHost)
+    final ServerSocket serverSocket = new ServerSocket(port, 1, InetAddress.loopbackAddress)
     return new Reader(serverSocket)
   }
 
@@ -73,7 +73,7 @@ final class ServiceProtocol {
 
     def write(final String command) {
       log.debug 'ServiceProtocol.send({}, {})', port, command
-      Socket s = new Socket(InetAddress.localHost, port)
+      Socket s = new Socket(InetAddress.loopbackAddress, port)
       try {
         OutputStream out = s.getOutputStream()
         out.write(("${command}\n<<EOF>>\n").getBytes(StandardCharsets.UTF_8))


### PR DESCRIPTION
Fixes #191 by using loopbackAddress instead of localHost.

I've verified this change solves the problem from issue #191. I don't think there is any way we could unit or integration test it, so for now, it's simply a manual test.