### PR TITLE
Restore missing server class name patterns in Jetty 11

### DIFF
--- a/libs/gretty-runner-jetty11/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty11/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -212,6 +212,9 @@ class JettyConfigurerImpl implements JettyConfigurer {
       include 'org.codehaus.groovy.'
       include 'groovy.'
       include 'groovyx.'
+      include 'groovyjarjarantlr.'
+      include 'groovyjarjarasm.'
+      include 'groovyjarjarcommonscli.'
     })
 
     context.addSystemClassMatcher(new ClassMatcher().tap {


### PR DESCRIPTION
When stripping the redundant FilteringClassLoader for Jetty 11
in ed5c9267058c95b526c88acefc3b6b012b53f863, I also stripped
the list of patterns which seemed unreasonable at the time.
I now learned that there exist packages with prefixes like
- groovyjarjarantlr
- groovyjarjarasm
- groovyjarjarcommonscli

inside the Groovy runtime JAR. Thus removal was not warranted.
The patterns have been deliberately added and constitute a
server class. This commit restores the previous pattern list
for Jetty 11, and makes it largely identical to the list of
Apache Tomcat 10 (compare with TomcatServerConfigurer#createContext).