### PR TITLE
Replace deprecated JavaExec.main usage with JavaExec.mainClass property

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/DefaultLauncher.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/DefaultLauncher.groovy
@@ -130,7 +130,7 @@ class DefaultLauncher extends LauncherBase {
       }
       spec.jvmArgs jvmArgs
       spec.systemProperties params.systemProperties
-      spec.main = params.main
+      spec.mainClass.set(params.main)
       spec.args = params.args
     }
   }


### PR DESCRIPTION
Gradle 7.1 will deprecate `JavaExec.getMain()` and `JavaExec.setMain()` in favor of `mainClass` property: https://github.com/gradle/gradle/pull/16734