### PR TITLE
Pick Groovy versions at runtime / Support JDK 16 (fixes #231)

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -1,0 +1,46 @@
+# #231 If we decide to drop Gradle 6 support / Groovy 2 support or upgrade minimum JDK requirements,
+# we might drop this build again.
+#
+# Extra one-off build for the transition from Gradle 6 to Gradle 7
+# Many things change under the hood: Gradle version, JDK version, Groovy version
+# In particular, we must ensure that Gretty built with
+#     Gradle 6, Groovy 2, Java 8
+# works well on
+#      Gradle 7, Groovy 3, Java 16
+
+name: the-great-divide
+
+on: ['pull_request']
+
+jobs:
+  build-and-test:
+    name: Gradle Transition Build
+    runs-on: ubuntu-latest
+
+    env:
+      TEST_ALL_CONTAINERS: "['jetty9.3','jetty9.4','tomcat85','tomcat9']"
+      GRADLE7_PROPERTIES: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0-milestone-2'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
+
+      - name: Build
+        run: ./gradlew --no-daemon --warning-mode all build
+
+      - name: Download Gradle 7
+        run: ./gradlew --no-daemon wrapper --gradle-version 7.1 --distribution-type all
+
+      - name: Set up JDK 16
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 16
+
+      - name: Test
+        run: cd integrationTests && ../gradlew --no-daemon --warning-mode all $GRADLE7_PROPERTIES -PgeckoDriverPlatform=linux64 -PtestAllContainers=$TEST_ALL_CONTAINERS testAll

--- a/libs/gretty-common/build.gradle
+++ b/libs/gretty-common/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
-	api localGroovy()
+	// #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+	compileOnly localGroovy()
+
 	api "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/libs/gretty-core/build.gradle
+++ b/libs/gretty-core/build.gradle
@@ -5,7 +5,9 @@ plugins {
 import org.apache.tools.ant.filters.*
 
 dependencies {
-  api localGroovy()
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api "ch.qos.logback:logback-classic:$logback_version"
   api 'commons-cli:commons-cli:1.3.1'
   api 'commons-configuration:commons-configuration:1.10'

--- a/libs/gretty-filter/build.gradle
+++ b/libs/gretty-filter/build.gradle
@@ -7,8 +7,11 @@ dependencies {
   api 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1', {
     exclude group: 'commons-logging', module: 'commons-logging'
   }
-  api localGroovy()
-  api "org.codehaus.groovy:groovy-jmx:${GroovySystem.version}"
-  api "org.codehaus.groovy:groovy-servlet:${GroovySystem.version}"
+
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+  compileOnly "org.codehaus.groovy:groovy-jmx:${GroovySystem.version}"
+  compileOnly "org.codehaus.groovy:groovy-servlet:${GroovySystem.version}"
+
   api "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/libs/gretty-runner-jetty/build.gradle
+++ b/libs/gretty-runner-jetty/build.gradle
@@ -3,5 +3,8 @@ plugins {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner')
 }

--- a/libs/gretty-runner-jetty7/build.gradle
+++ b/libs/gretty-runner-jetty7/build.gradle
@@ -11,6 +11,9 @@ configurations {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-jetty')
   api "javax.servlet:servlet-api:$jetty7_servlet_api_version"
   api "org.eclipse.jetty:jetty-server:$jetty7_version"

--- a/libs/gretty-runner-jetty8/build.gradle
+++ b/libs/gretty-runner-jetty8/build.gradle
@@ -9,6 +9,9 @@ configurations {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-jetty')
   api "javax.servlet:javax.servlet-api:$jetty8_servlet_api_version"
   api "org.eclipse.jetty:jetty-server:$jetty8_version"

--- a/libs/gretty-runner-jetty9/build.gradle
+++ b/libs/gretty-runner-jetty9/build.gradle
@@ -9,6 +9,9 @@ configurations {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-jetty')
   api "javax.servlet:javax.servlet-api:$jetty9_servlet_api_version"
   api "org.eclipse.jetty:jetty-server:$jetty9_version"

--- a/libs/gretty-runner-jetty93/build.gradle
+++ b/libs/gretty-runner-jetty93/build.gradle
@@ -9,6 +9,9 @@ configurations {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-jetty')
   api "javax.servlet:javax.servlet-api:$jetty9_servlet_api_version"
   api "org.eclipse.jetty:jetty-server:$jetty93_version"

--- a/libs/gretty-runner-jetty94/build.gradle
+++ b/libs/gretty-runner-jetty94/build.gradle
@@ -9,6 +9,9 @@ configurations {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-jetty')
   api "javax.servlet:javax.servlet-api:$jetty9_servlet_api_version"
   api "org.eclipse.jetty:jetty-server:$jetty94_version"

--- a/libs/gretty-runner-tomcat/build.gradle
+++ b/libs/gretty-runner-tomcat/build.gradle
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner')
   api "org.slf4j:log4j-over-slf4j:$slf4j_version"
   // These dependencies are needed for compiling gretty-runner-tomcat.

--- a/libs/gretty-runner-tomcat85/build.gradle
+++ b/libs/gretty-runner-tomcat85/build.gradle
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-tomcat8plus'), {
     exclude group: 'org.apache.tomcat.embed'
     exclude group: 'javax.servlet', module: 'javax.servlet-api'

--- a/libs/gretty-runner-tomcat8plus/build.gradle
+++ b/libs/gretty-runner-tomcat8plus/build.gradle
@@ -3,6 +3,9 @@ plugins {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-tomcat'), {
 	exclude group: 'org.apache.tomcat.embed'
 	exclude group: 'javax.servlet', module: 'javax.servlet-api'

--- a/libs/gretty-runner-tomcat9/build.gradle
+++ b/libs/gretty-runner-tomcat9/build.gradle
@@ -3,6 +3,9 @@ plugins {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api project(':libs:gretty-runner-tomcat85'), {
     exclude group: 'org.apache.tomcat.embed'
     exclude group: 'javax.servlet', module: 'javax.servlet-api'

--- a/libs/gretty-runner/build.gradle
+++ b/libs/gretty-runner/build.gradle
@@ -3,9 +3,11 @@ plugins {
 }
 
 dependencies {
-  api localGroovy()
-  api "org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"
-  api "org.codehaus.groovy:groovy-json:${GroovySystem.version}"
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+  compileOnly "org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"
+  compileOnly "org.codehaus.groovy:groovy-json:${GroovySystem.version}"
+
   api 'commons-cli:commons-cli:1.3.1'
   api 'commons-io:commons-io:2.4'
   api "ch.qos.logback:logback-classic:$logback_version"

--- a/libs/gretty-spock/build.gradle
+++ b/libs/gretty-spock/build.gradle
@@ -3,7 +3,9 @@ plugins {
 }
 
 dependencies {
-  api localGroovy()
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   api libs.spock
   api 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 }

--- a/libs/gretty-springboot/build.gradle
+++ b/libs/gretty-springboot/build.gradle
@@ -3,8 +3,10 @@ plugins {
 }
 
 dependencies {
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+
   providedCompile 'javax.servlet:javax.servlet-api:3.0.1'
-  api localGroovy()
   api "org.springframework.boot:spring-boot-starter-web:$springBootVersion", {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
   }

--- a/libs/gretty-starter/build.gradle
+++ b/libs/gretty-starter/build.gradle
@@ -3,7 +3,10 @@ plugins {
 }
 
 dependencies {
-  api "org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"
+  // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  compileOnly localGroovy()
+  compileOnly "org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"
+
   api project(':libs:gretty-core')
 }
 

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/DefaultLauncher.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/DefaultLauncher.groovy
@@ -11,6 +11,8 @@ package org.akhikhl.gretty
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory
 import org.gradle.process.JavaExecSpec
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
@@ -31,8 +33,18 @@ class DefaultLauncher extends LauncherBase {
 
   static Collection<URL> getRunnerClassPath(Project project, ServerConfig sconfig) {
     def files = project.configurations.grettyNoSpringBoot.files +
-        project.configurations[ServletContainerConfig.getConfig(sconfig.servletContainer).servletContainerRunnerConfig].files
+        project.configurations[ServletContainerConfig.getConfig(sconfig.servletContainer).servletContainerRunnerConfig].files +
+            getCurrentGroovy(project)
     (files.collect { it.toURI().toURL() }) as LinkedHashSet
+  }
+
+  // #231 If we decide to drop Gradle 6 / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+  static Configuration getCurrentGroovy(Project project) {
+    project.configurations.detachedConfiguration(
+            project.dependencies.create(DependencyFactory.ClassPathNotation.LOCAL_GROOVY),
+            project.dependencies.create("org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"),
+            project.dependencies.create("org.codehaus.groovy:groovy-json:${GroovySystem.version}"),
+    )
   }
 
   private Collection<URL> runnerClasspath

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
@@ -38,6 +38,13 @@ class ServletContainerConfig {
           project.dependencies.add 'runtimeOnly', "org.gretty:gretty-filter:${project.ext.grettyVersion}", {
             exclude group: 'javax.servlet', module: 'servlet-api'
           }
+
+          // #231 If we decide to drop Gradle 6 support / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
+          // Fingers crossed that users of gretty-filter update Gradle and Groovy versions in tandem.
+          // Likely, building a Groovy 2 project with a build system of Gradle 7 / Groovy 3 would not work
+          // because below drags in the wrong versions.
+          project.dependencies.add("runtimeOnly", "org.codehaus.groovy:groovy-jmx:${GroovySystem.version}")
+          project.dependencies.add("runtimeOnly", "org.codehaus.groovy:groovy-servlet:${GroovySystem.version}")
           alteredDependencies = true
         }
       }


### PR DESCRIPTION
Instead of relying on the Groovy versions that Gretty was built with, we must choose Groovy versions at runtime. As a result, the classpath of runner contains Groovy 2 on Gradle 6, and Groovy 3 on Gradle 7.

I commented exhaustively because we might get rid of this behavior when we deprecate support for Gradle 6 / Groovy 2. Actually, just letting the Gretty modules put the Groovy versions on the classpath is much easier to reason about.
Also, the dependencies in the `compileOnly` config are not transitive, such that I had to add Groovy dependencies to all projects, otherwise they would not compile.

The case of `gretty-filter` is particularly interesting (and broken in some instances, to my belief). When adding `gretty-filter`, we mess with the classpath of the webapp. If someone was building Groovy 2.x projects with Gradle 7, Gretty might drag in the wrong dependencies (as of now). I think those people could just continue to use the current release without issue.

As promised, I added a build job covering regressions. I think running it on pull requests is enough, it's quite expensive without caching and that stuff. It need not run on every push.

Finally, because Gradle 7 and Groovy 3 support Java 16, Gretty does now also support it 🎉 