### PR TITLE
Rework transition build for master

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -4,13 +4,13 @@
 # Extra one-off build for the transition from Gradle 6 to Gradle 7
 # Many things change under the hood: Gradle version, JDK version, Groovy version
 # In particular, we must ensure that Gretty built with
-#     Gradle 6, Groovy 2, Java 8
+#     Gradle 6, Groovy 2, Java 11
 # works well on
-#      Gradle 7, Groovy 3, Java 16
+#      Gradle 7, Groovy 3, Java 17
 
 name: the-great-divide
 
-on: ['pull_request']
+on: ['pull_request', 'workflow_dispatch']
 
 jobs:
   build-and-test:
@@ -24,23 +24,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 11
 
       - name: Build
         run: ./gradlew --no-daemon --warning-mode all build
 
       - name: Download Gradle 7
-        run: ./gradlew --no-daemon wrapper --gradle-version 7.1.1 --distribution-type all
+        run: ./gradlew --no-daemon wrapper --gradle-version 7.3 --distribution-type all
 
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 16
+          java-version: 17
 
       - name: Test
         run: cd integrationTests && ../gradlew --no-daemon --warning-mode all $GRADLE7_PROPERTIES -PgeckoDriverPlatform=linux64 -PtestAllContainers=$TEST_ALL_CONTAINERS testAll


### PR DESCRIPTION
This build has never worked for master.
We set the new minimum JDK requirement to 11, and had this build test the migration rooted in JDK 8.
As a result, we must raise the JDK version for compilation to 11, and the JDK version for test to 17 (the current LTS version).

Let's see if everything works again 🤞 