### PR TITLE
Gradle 7.4 and JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
           - java: 15
             gradle: '7.3.3'
             properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'
-
+          - java: 15
+            gradle: '7.4'
+            properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'
     env:
       TEST_ALL_CONTAINERS: "['tomcat10','jetty11']"
       GRADLE_VERSION: ${{ matrix.gradle }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Begin workaround: because the current Gradle wrapper does not support Java 17,
+      # we use JDK 15 to bootstrap the appropriate Gradle version, and then proceed
+      # to use a recent version of Gradle and Java.
+      - name: Set up JDK 15
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 15
+      - name: Bootstrap Gradle version
+        run: ./gradlew --no-daemon wrapper --gradle-version $GRADLE_VERSION --distribution-type all
+      # end workaround
+
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
@@ -43,9 +55,9 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.GRADLE_VERSION }}-${{ hashFiles('**/*.gradle', 'gradle.properties') }}
 
       - name: Build and Test
+        # ./gradlew --no-daemon wrapper --gradle-version $GRADLE_VERSION --distribution-type all
         run: |
           set -e
-          ./gradlew --no-daemon wrapper --gradle-version $GRADLE_VERSION --distribution-type all
           ./gradlew --no-daemon --warning-mode all $EXTRA_PROPERTIES build
           cd integrationTests
           ../gradlew --no-daemon --warning-mode all $EXTRA_PROPERTIES -PgeckoDriverPlatform=linux64 -PtestAllContainers=$TEST_ALL_CONTAINERS testAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
         gradle: ['6.9.2']
         include:
           - java: 17
-            gradle: '7.3.3'
-            properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'
-          - java: 17
             gradle: '7.4'
             properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'
+
     env:
       TEST_ALL_CONTAINERS: "['tomcat10','jetty11']"
       GRADLE_VERSION: ${{ matrix.gradle }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
         java: [11]
         gradle: ['6.9.2']
         include:
+          - java: 11
+            gradle: '7.4'
+            properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'
           - java: 17
             gradle: '7.4'
             properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
         java: [11]
         gradle: ['6.9.2']
         include:
-          - java: 15
+          - java: 17
             gradle: '7.3.3'
             properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'
-          - java: 15
+          - java: 17
             gradle: '7.4'
             properties: '-Pspock_version=2.0-groovy-3.0 -PgebVersion=5.0'
     env:

--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew --no-daemon --warning-mode all build
 
       - name: Download Gradle 7
-        run: ./gradlew --no-daemon wrapper --gradle-version 7.3.3 --distribution-type all
+        run: ./gradlew --no-daemon wrapper --gradle-version 7.4 --distribution-type all
 
       - name: Set up JDK 17
         uses: actions/setup-java@v2


### PR DESCRIPTION
Draft pull request - we'll need to get our versioning and release schedules sorted first. I just wanted to show that Gretty in principle builds against JDK 17, and also does work with Gradle 7.4