### PR TITLE
Replace internal Gradle API usage with public API

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/JacocoHelper.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/JacocoHelper.groovy
@@ -1,15 +1,15 @@
 package org.akhikhl.gretty
 
-import org.gradle.api.internal.TaskInputsInternal
-import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.TaskOutputsInternal
-import org.gradle.api.internal.tasks.TaskStateInternal
+import org.gradle.api.Task
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskInputs
+import org.gradle.api.tasks.TaskOutputs
+import org.gradle.api.tasks.TaskState
 import org.gradle.process.JavaForkOptions
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 
-interface JacocoHelper extends TaskInternal, JavaForkOptions, ExtensionAware {
+interface JacocoHelper extends Task, JavaForkOptions, ExtensionAware {
   @Internal
   JacocoTaskExtension getJacoco()
 
@@ -23,15 +23,15 @@ interface JacocoHelper extends TaskInternal, JavaForkOptions, ExtensionAware {
 
   @Internal
   @Override
-  TaskInputsInternal getInputs()
+  TaskInputs getInputs()
 
   @Internal
   @Override
-  TaskOutputsInternal getOutputs()
+  TaskOutputs getOutputs()
 
   @Internal
   @Override
-  TaskStateInternal getState()
+  TaskState getState()
 
   @Internal
   @Override

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -15,7 +15,6 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 /**
@@ -30,7 +29,7 @@ final class ProjectUtils {
   // #231 If we decide to drop Gradle 6 / Groovy 2 support, we can drop choosing Groovy versions at runtime again.
   static Configuration getCurrentGroovy(Project project) {
     project.configurations.detachedConfiguration(
-            project.dependencies.create(DependencyFactory.ClassPathNotation.LOCAL_GROOVY),
+            project.dependencies.localGroovy(),
             project.dependencies.create("org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"),
             project.dependencies.create("org.codehaus.groovy:groovy-json:${GroovySystem.version}"),
     )

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
@@ -13,11 +13,8 @@ import groovy.transform.TypeCheckingMode
 import org.akhikhl.gretty.scanner.JDKScannerManager
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
-import org.gradle.api.internal.TaskInternal
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.JavaForkOptions
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
@@ -156,7 +153,7 @@ abstract class StartBaseTask extends DefaultTask {
   private void initJacoco() {
     if(project.extensions.findByName('jacoco') && project.gretty.jacocoEnabled) {
       Task startTask = this
-      jacocoHelper = (TaskInternal.methods.collectEntries({ [it.name, {} ] }) +
+      jacocoHelper = (Task.methods.collectEntries({ [it.name, {} ] }) +
           JavaForkOptions.methods.collectEntries({ [it.name, {} ] }) +
           ExtensionAware.methods.collectEntries({ [it.name, {} ] }) + [
           getExtensions: { startTask.getExtensions() },


### PR DESCRIPTION
There is no clear reason to use these internal APIs, and it's preventing me from making changes to internal APIs in https://github.com/gradle/gradle/pull/20868. Please let me know if there are reasons you needed to reference these, and we can try to figure out a good path forward.

I would also like these changes backported to 3.x if they are accepted, I can make a PR for that if you like.