### PR TITLE
Remove check for missing slf4j provider

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
@@ -123,13 +123,6 @@ class GrettyPlugin implements Plugin<Project> {
     for(String overlay in project.gretty.overlays)
       project.dependencies.add 'grettyProvidedCompile', project.project(overlay)
 
-    def runtimeConfig = project.configurations.findByName('runtimeClasspath')
-    if(runtimeConfig) {
-      if(runtimeConfig.allDependencies.find { it.name == 'slf4j-api' } && !runtimeConfig.allDependencies.find { it.name in ['slf4j-nop', 'slf4j-simple', 'slf4j-log4j12', 'slf4j-jdk14', 'logback-classic', 'log4j-slf4j-impl'] }) {
-        log.warn("Found slf4j-api dependency but no providers were found.  Did you mean to add slf4j-simple? See https://www.slf4j.org/codes.html#noProviders .")
-      }
-    }
-
     project.farms.farmsMap.each { fname, farm ->
       farm.webAppRefs.each { wref, options ->
         def typeAndResult = FarmConfigurerUtil.resolveWebAppType(project, options.suppressMavenToProjectResolution, wref)


### PR DESCRIPTION
Fixes #275

Slf4j issues a warning in case the provider is missing. Furthermore, the checked provider list might not be complete and is currently outdated resulting in false-positives.