### PR TITLE
fix jettyStart throws exception if using jetty-env.xml

### DIFF
--- a/libs/gretty-runner-jetty11/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty11/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -250,7 +250,7 @@ class JettyConfigurerImpl implements JettyConfigurer {
   URL findResourceURL(baseResource, String path) {
     Resource res = baseResource.addPath(path)
     if(res.exists())
-      return res.getURL()
+      return res.getURI().toURL()
     null
   }
 


### PR DESCRIPTION
fix #299 