### PR TITLE
Fix jetty redeploy with custom jetty-env.xml

### DIFF
--- a/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
+++ b/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
@@ -101,9 +101,15 @@ final class Runner {
           }
         }
         else if (data.startsWith('redeploy ')) {
-          List<String> webappList = data.replace('redeploy ', '').split(' ').toList()
-          serverManager.redeploy(webappList)
-          writer.writeMayFail('redeployed')
+          ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader()
+          Thread.currentThread().setContextClassLoader(cl)
+          try {
+            List<String> webappList = data.replace('redeploy ', '').split(' ').toList()
+            serverManager.redeploy(webappList)
+            writer.writeMayFail('redeployed')
+          } finally {
+            Thread.currentThread().setContextClassLoader(oldClassLoader)
+          }
         }
       }
     } finally {


### PR DESCRIPTION
Redeploy would fail because runner classloader is separate from the servlet container classloader. So runner was not able to create new WebAppContext.