### PR TITLE
Support folders under "src/resources" in fastReload configuration property

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/scanner/BaseScannerManager.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/scanner/BaseScannerManager.groovy
@@ -188,7 +188,10 @@ abstract class BaseScannerManager implements ScannerManager {
             }.each { wconfig ->
                 log.info 'changed file {} affects project {}', f, wconfig.projectPath
                 def proj = project.project(wconfig.projectPath)
-                if(proj.sourceSets.main.allSource.srcDirs.find { f.startsWith(it.absolutePath) }) {
+                if(ProjectReloadUtils.satisfiesOneOfReloadSpecs(f, fastReloadMap[proj.path])) {
+                    log.info 'file {} is in fastReload directories', f
+                    reloadProject(wconfig.projectPath, 'fastReload')
+                } else if(proj.sourceSets.main.allSource.srcDirs.find { f.startsWith(it.absolutePath) }) {
                     if(wconfig.recompileOnSourceChange) {
                         reloadProject(wconfig.projectPath, 'compile')
                         // restart is done when reacting to class change, not source change
@@ -219,9 +222,6 @@ abstract class BaseScannerManager implements ScannerManager {
                         reloadProject(wconfig.projectPath, 'compile')
                         webAppConfigsToRestart.add(wconfig)
                     }
-                } else if(ProjectReloadUtils.satisfiesOneOfReloadSpecs(f, fastReloadMap[proj.path])) {
-                    log.info 'file {} is in fastReload directories', f
-                    reloadProject(wconfig.projectPath, 'fastReload')
                 } else {
                     log.info 'file {} is not in fastReload directories, switching to fullReload', f
                     reloadProject(wconfig.projectPath, 'compile')


### PR DESCRIPTION
When hotreload is enabled, gretty watches and always recompile/redeploy webapp if there are any changes in "src/java" or "src/resources". That is inconvenient when one has many static resources in "src/resources" that don't require recompilation/redeploy.

This change makes sure that fastReload check is performed before recompile check for sources. So as a workaround one can specify such folders under `src/resources` as fastReload and prevent recompilation/redeploy.