### PR TITLE
provide a clear list of supported containers

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
@@ -120,7 +120,7 @@ class ServletContainerConfig {
     servletContainer = servletContainer ?: 'jetty11'
     def result = configs[servletContainer.toString()]
     if(!result)
-      throw new Exception("Unsupported servlet container: $servletContainer")
+      throw new Exception("Unsupported servlet container: $servletContainer. Only ${configs.keySet()} are supported")
     result
   }
 


### PR DESCRIPTION
When displaying "Unsupported servlet container," provide a clear list of supported containers to help users troubleshoot the issue.