### PR TITLE
Migrate groovy.util.XmlSlurper to groovy.xml.XmlSlurper

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
@@ -32,7 +32,7 @@ class ServletContainerConfig {
       boolean alteredDependencies = false
       File webXmlFile = new File(ProjectUtils.getWebAppDir(proj), 'WEB-INF/web.xml')
       if(webXmlFile.exists()) {
-        def webXml = new XmlSlurper().parse(webXmlFile)
+        def webXml = new groovy.xml.XmlSlurper().parse(webXmlFile)
         if(webXml.filter.find { it.'filter-class'.text() == 'org.akhikhl.gretty.RedirectFilter' }) {
           project.dependencies.add 'runtimeOnly', "org.gretty:gretty-filter:${project.ext.grettyVersion}", {
             exclude group: 'javax.servlet', module: 'servlet-api'


### PR DESCRIPTION
* Potentially fixes https://github.com/gretty-gradle-plugin/gretty/issues/320

Opening this PR to run your CI on it.

Note: there might be other changes needed for full Gradle 9 support.