### PR TITLE
bcprov-jdk18 upgraded to 1.81 - CVE-2024-30172 fix

### DIFF
--- a/libs/gretty-core/build.gradle
+++ b/libs/gretty-core/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   api 'commons-configuration:commons-configuration:1.10'
   api "commons-io:commons-io:$commons_io_version"
   api 'org.apache.commons:commons-lang3:3.12.0'
-  api 'org.bouncycastle:bcprov-jdk18on:1.77'
+  api 'org.bouncycastle:bcprov-jdk18on:1.81'
   api project(':libs:gretty-common')
 }
 


### PR DESCRIPTION
Fixed [issue-307](https://github.com/gretty-gradle-plugin/gretty/issues/307)